### PR TITLE
[BUGFIX] nav filter clear btn position

### DIFF
--- a/src/components/c-vas-navigation-filter.vue
+++ b/src/components/c-vas-navigation-filter.vue
@@ -31,7 +31,7 @@
     name: 'c-vas-navigation-filter',
 
     components: {
-      eVasInput
+      eVasInput,
     },
 
     props: {
@@ -112,7 +112,7 @@
       justify-content: center;
       align-items: center;
       cursor: pointer;
-      height: 30px;
+      height: 100%;
     }
 
     &__close-icon {


### PR DESCRIPTION
fixes nav filter clear btn position

## Before

<img width="311" height="286" alt="Screenshot 2025-10-22 at 13 14 37" src="https://github.com/user-attachments/assets/5ca22f8b-aa8d-4b17-8750-f8205a42d0ac" />

## Now

<img width="330" height="268" alt="Screenshot 2025-10-22 at 13 14 44" src="https://github.com/user-attachments/assets/faf4a2d2-6280-40c3-86d8-99f66546296f" />
