### PR TITLE
feat(e2e): add keyboard navigation tests for c-vas-navigation

### DIFF
--- a/specs/c-vas-navigation-keyboard.md
+++ b/specs/c-vas-navigation-keyboard.md
@@ -1,0 +1,89 @@
+# Test Plan: `c-vas-navigation` Keyboard Navigation
+
+**Target:** `tests/e2e/c-vas-navigation-keyboard.spec.ts`  
+**Seed:** `tests/e2e/seed.spec.ts`  
+**Page:** `http://127.0.0.1:4173/sg-components/sg-test-page-navigation`
+
+## Test Structure
+
+```typescript
+import { expect, test } from '@playwright/test';
+
+test.describe('c-vas-navigation keyboard navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/sg-components/sg-test-page-navigation');
+  });
+```
+
+## Scenario 1: Menu is visible
+
+```typescript
+test('menu is visible with search input', async ({ page }) => {
+  await expect(page.getByTestId('nav-menu')).toBeVisible();
+
+  const searchInput = page.getByTestId('nav-search');
+  await expect(searchInput).toBeVisible();
+  await expect(searchInput).toHaveAttribute('placeholder', 'Search …');
+});
+```
+
+## Scenario 2: Search filters the menu
+
+```typescript
+test('search filters navigation items', async ({ page }) => {
+  const searchInput = page.getByTestId('nav-search');
+  const navItems = page.getByTestId('nav-item');
+
+  const initialCount = await navItems.count();
+
+  await searchInput.fill('components');
+
+  await expect(navItems.first()).toBeVisible();
+
+  const filteredCount = await navItems.count();
+  expect(filteredCount).toBeLessThanOrEqual(initialCount);
+  expect(filteredCount).toBeGreaterThan(0);
+});
+```
+
+## Scenario 3: ArrowDown/ArrowUp navigation
+
+```typescript
+test('arrow keys navigate menu items', async ({ page }) => {
+  const searchInput = page.getByTestId('nav-search');
+  const selectedItem = page.getByTestId('nav-item-selected');
+
+  await searchInput.focus();
+
+  await searchInput.press('ArrowDown');
+
+  await expect(selectedItem).toBeVisible();
+
+  const firstSelectedText = await selectedItem.textContent();
+
+  await searchInput.press('ArrowDown');
+
+  const secondSelectedText = await selectedItem.textContent();
+  expect(firstSelectedText).not.toBe(secondSelectedText);
+
+  await searchInput.press('ArrowUp');
+
+  await expect(selectedItem).toHaveText(firstSelectedText);
+});
+```
+
+## Test IDs Used
+
+| Element        | Test ID             |
+| -------------- | ------------------- |
+| Menu container | `nav-menu`          |
+| Search input   | `nav-search`        |
+| Nav items      | `nav-item`          |
+| Selected item  | `nav-item-selected` |
+
+## Notes
+
+- Uses Playwright's `expect().toBeVisible()` for robust assertions
+- No hard-coded titles or random child element references
+- No `networkidle` or fixed sleeps
+- Follows existing seed test patterns (`test.describe`, `async ({ page })`)

--- a/src/components/c-vas-navigation-block.vue
+++ b/src/components/c-vas-navigation-block.vue
@@ -11,6 +11,7 @@
           selected: isSelected,
         })
       "
+      :data-testid="isSelected ? 'nav-item-selected' : 'nav-item'"
       @click.prevent="onItemClick"
     >
       {{ routeTitle }}

--- a/src/components/c-vas-navigation-filter.vue
+++ b/src/components/c-vas-navigation-filter.vue
@@ -8,6 +8,7 @@
       placeholder="Search …"
       autofocus
       select-on-focus
+      data-testid="nav-search"
       @click.stop
     />
     <button

--- a/src/components/c-vas-navigation.vue
+++ b/src/components/c-vas-navigation.vue
@@ -10,7 +10,10 @@
       :class="b('filter')"
     />
 
-    <div :class="b('menu')">
+    <div
+      :class="b('menu')"
+      data-testid="nav-menu"
+    >
       <c-vas-navigation-block
         v-for="routeItem in groupedRoutes"
         :key="`${routeItem.name as string}-${navigationFilter}`"

--- a/tests/e2e/c-vas-navigation-keyboard.spec.ts
+++ b/tests/e2e/c-vas-navigation-keyboard.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('c-vas-navigation keyboard navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/sg-components/sg-test-page-navigation');
+  });
+
+  test('menu is visible with search input', async ({ page }) => {
+    await expect(page.getByTestId('nav-menu')).toBeVisible();
+
+    const searchInput = page.getByTestId('nav-search');
+
+    await expect(searchInput).toBeVisible();
+    await expect(searchInput).toHaveAttribute('placeholder', 'Search …');
+  });
+
+  test('search filters navigation items', async ({ page }) => {
+    const searchInput = page.getByTestId('nav-search');
+    const navItems = page.getByTestId('nav-item');
+
+    // Wait for initial nav items to be visible before counting
+    await expect(navItems.first()).toBeVisible();
+
+    const initialCount = await navItems.count();
+
+    await searchInput.fill('components');
+
+    await expect(navItems.first()).toBeVisible();
+
+    const filteredCount = await navItems.count();
+
+    expect(filteredCount).toBeLessThanOrEqual(initialCount);
+    expect(filteredCount).toBeGreaterThan(0);
+
+    // Verify "Elements" is not in the filtered results
+    const allItemsText = await navItems.allTextContents();
+    const hasElements = allItemsText.some((text) => text.includes('Elements'));
+
+    expect(hasElements).toBe(false);
+  });
+
+  test('arrow keys navigate menu items', async ({ page }) => {
+    const searchInput = page.getByTestId('nav-search');
+    const selectedItem = page.getByTestId('nav-item-selected');
+
+    await searchInput.focus();
+
+    await searchInput.press('ArrowDown');
+
+    await expect(selectedItem).toBeVisible();
+
+    const firstSelectedText = (await selectedItem.textContent()) ?? '';
+
+    await searchInput.press('ArrowDown');
+
+    const secondSelectedText = (await selectedItem.textContent()) ?? '';
+
+    expect(firstSelectedText).not.toBe(secondSelectedText);
+
+    await searchInput.press('ArrowUp');
+
+    await expect(selectedItem).toHaveText(firstSelectedText);
+  });
+});


### PR DESCRIPTION
- Add data-testid attributes to navigation components (nav-menu, nav-search, nav-item, nav-item-selected)
- Add e2e tests for:
  - Menu and search input visibility
  - Search filtering functionality
  - ArrowDown/ArrowUp keyboard navigation
- Add test plan document

## Pull request

_description_

### Ticket / Issue

- https://github.com/valantic/vue-styleguide/issues/xx

### Browser testing

- `npm run test` > works without errors
- `npm run dev`
- url-to-test

### Checklist

- [ ] I merged the current main branch (before testing)
- [ ] Added JSDoc and styleguide demo
- [ ] Did run automated tests and linters

## Review/Test checklist

- [ ] Did review code and documentation
