### PR TITLE
add custom sort order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- [ENHANCEMENT] Add the possibility to custom sort styleguide routes in the sidebar.
+
 ## v1.2.0
 
 - [ENHANCEMENT] Add reset styles to styleguide components l-vas-layout and c-vas-sidebar.

--- a/src/components/c-vas-navigation.vue
+++ b/src/components/c-vas-navigation.vue
@@ -246,6 +246,22 @@
             return 0;
           }
 
+          // Check for custom sorting using sortOrder.
+          const firstSortOrder = first.meta.sortOrder as number | undefined;
+          const secondSortOrder = second.meta.sortOrder as number | undefined;
+
+          if (firstSortOrder !== undefined && secondSortOrder !== undefined) {
+            return firstSortOrder - secondSortOrder;
+          }
+
+          if (firstSortOrder !== undefined) {
+            return -1;
+          }
+
+          if (secondSortOrder !== undefined) {
+            return 1;
+          }
+
           if (first.meta.title < second.meta.title) {
             return -1;
           }

--- a/src/styleguide/setup/routes.ts
+++ b/src/styleguide/setup/routes.ts
@@ -58,6 +58,7 @@ export default [
         component: () => import('../demo-pages/components/r-navigation.vue'),
         meta: {
           title: 'Navigation',
+          sortOrder: 2,
         },
       },
       {
@@ -66,6 +67,7 @@ export default [
         component: () => import('../demo-pages/components/r-vas-modal.vue'),
         meta: {
           title: 'Modal',
+          sortOrder: 1,
         },
       },
       {

--- a/src/styleguide/setup/routes.ts
+++ b/src/styleguide/setup/routes.ts
@@ -19,6 +19,7 @@ export default [
     redirect: '/sg/sg-test-page-readme',
     meta: {
       title: 'Styleguide',
+      sortOrder: 1,
     },
     children: [
       styleguideTestPages.readme,
@@ -48,6 +49,7 @@ export default [
     component: styleguideRouterConfig.routeChildrenComponentWrapper,
     meta: {
       title: 'Components',
+      sortOrder: 3,
     },
     children: [
       {
@@ -90,6 +92,7 @@ export default [
     component: styleguideRouterConfig.routeChildrenComponentWrapper,
     meta: {
       title: 'Elements',
+      sortOrder: 2,
     },
     children: [
       {

--- a/src/types/route.d.ts
+++ b/src/types/route.d.ts
@@ -3,6 +3,7 @@ import { ComponentPublicInstance } from 'vue';
 export type RouteMeta = {
   title: string;
   alternativeTitles?: string[];
+  sortOrder?: number;
   params?: {
     [key: string]: string;
   };

--- a/tests/unit/specs/components/c-vas-navigation.test.ts
+++ b/tests/unit/specs/components/c-vas-navigation.test.ts
@@ -48,4 +48,46 @@ describe('c-vas-navigation', () => {
     expect(filteredRoutes[1]?.children?.[0]?.meta?.title).toBe('Sub A');
     expect(filteredRoutes[1]?.children?.[1]?.meta?.title).toBe('Sub B');
   });
+
+  test('should sort routes by sortOrder if provided', () => {
+    const customRoutes: RouteRecordRaw[] = [
+      {
+        path: '/b',
+        name: 'b',
+        meta: { title: 'B', sortOrder: 1 },
+        redirect: '',
+      },
+      {
+        path: '/a',
+        name: 'a',
+        meta: { title: 'A', sortOrder: 2 },
+        redirect: '',
+      },
+      {
+        path: '/c',
+        name: 'c',
+        meta: { title: 'C' }, // No sortOrder, should come after those with sortOrder
+        redirect: '',
+      },
+    ];
+
+    const wrapper = mount(cVasNavigation, {
+      global: {
+        plugins: [vueBemCn],
+        stubs: {
+          'c-vas-navigation-filter': true,
+          'c-vas-navigation-block': true,
+        },
+      },
+      props: {
+        routes: customRoutes,
+      },
+    });
+
+    const filteredRoutes = (wrapper.vm as unknown as { filteredRoutes: RouteRecordRaw[] }).filteredRoutes;
+
+    expect(filteredRoutes[0]?.meta?.title).toBe('B'); // sortOrder 1
+    expect(filteredRoutes[1]?.meta?.title).toBe('A'); // sortOrder 2
+    expect(filteredRoutes[2]?.meta?.title).toBe('C'); // No sortOrder
+  });
 });


### PR DESCRIPTION
## Pull request

Adds possibility to custom sort the groups and titles if wanted.

### Ticket / Issue

- https://github.com/valantic/vue-styleguide/issues/30

### Browser testing

- `npm run test` > works without errors
- `npm run dev`
- http://localhost:5173/sg/sg-test-page-readme

### Checklist

- [x] I merged the current main branch (before testing)
- [x] Added JSDoc and styleguide demo
- [x] Did run automated tests and linters

## Review/Test checklist

- [ ] Did review code and documentation
