### PR TITLE
Feature/13 store page configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- [ENHANCEMENT] Add helper and example for persisting page configuration.
 - [ENHANCEMENT] Add the possibility to custom sort styleguide routes in the sidebar.
 
 ## v1.2.0

--- a/src/components/c-vas-config.vue
+++ b/src/components/c-vas-config.vue
@@ -1,5 +1,12 @@
 <template>
   <div :class="b()">
+    <e-vas-button
+      type="button"
+      @click="clearAllPersistedValues"
+    >
+      Remove persisted values
+    </e-vas-button>
+
     <slot name="globalSettings">
       <div :class="b('headline')">Global Settings</div>
       <c-vas-html-validation />
@@ -17,10 +24,9 @@
 
 <script lang="ts">
   import { defineComponent } from 'vue';
+  import { clearAllPersistentItems } from '@/stores/helper';
+  import eVasButton from '@/elements/e-vas-button.vue';
   import cVasHtmlValidation from './c-vas-html-validation.vue';
-
-  // type Setup = {};
-  // type Data = {};
 
   /**
    * Component for managing global settings.
@@ -29,35 +35,18 @@
     name: 'c-vas-config',
 
     components: {
+      eVasButton,
       cVasHtmlValidation,
     },
 
-    // props: {},
-    // emits: {},
-
-    // setup(): Setup {
-    //   return {};
-    // },
-    // data(): Data {
-    //   return {};
-    // },
-
-    // computed: {},
-    // watch: {},
-
-    // beforeCreate() {},
-    // created() {},
-    // beforeMount() {},
-    // mounted() {},
-    // beforeUpdate() {},
-    // updated() {},
-    // activated() {},
-    // deactivated() {},
-    // beforeUnmount() {},
-    // unmounted() {},
-
-    // methods: {},
-    // render() {},
+    methods: {
+      /**
+       * Clears all persistent items.
+       */
+      clearAllPersistedValues() {
+        clearAllPersistentItems();
+      },
+    },
   });
 </script>
 

--- a/src/stores/helper.ts
+++ b/src/stores/helper.ts
@@ -14,11 +14,13 @@ export const setInitialData = (state: State, initialData: InitialData) => {
   });
 };
 
+const prefix = 'vas-';
+
 /**
  * Get item from persistent storage and parse it.
  */
 export const getPersistentItem = <T>(key: string, fallback: T): T => {
-  const item = localStorage.getItem(key);
+  const item = localStorage.getItem(`${prefix}${key}`);
 
   if (!item) {
     return fallback;
@@ -39,7 +41,7 @@ export const getPersistentItem = <T>(key: string, fallback: T): T => {
  */
 export const setPersistentItem = (key: string, value: unknown): void => {
   try {
-    localStorage.setItem(key, JSON.stringify(value));
+    localStorage.setItem(`${prefix}${key}`, JSON.stringify(value));
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(`Failed to set persistent item with key "${key}"`, error);

--- a/src/stores/helper.ts
+++ b/src/stores/helper.ts
@@ -47,3 +47,14 @@ export const setPersistentItem = (key: string, value: unknown): void => {
     console.error(`Failed to set persistent item with key "${key}"`, error);
   }
 };
+
+/**
+ * Method to remove all persistent keys with prefix from styleguide.
+ */
+export const clearAllPersistentItems = (): void => {
+  Object.keys(localStorage).forEach((key) => {
+    if (key.startsWith(prefix)) {
+      localStorage.removeItem(key);
+    }
+  });
+};

--- a/src/stores/helper.ts
+++ b/src/stores/helper.ts
@@ -13,3 +13,35 @@ export const setInitialData = (state: State, initialData: InitialData) => {
     }
   });
 };
+
+/**
+ * Get item from persistent storage and parse it.
+ */
+export const getPersistentItem = <T>(key: string, fallback: T): T => {
+  const item = localStorage.getItem(key);
+
+  if (!item) {
+    return fallback;
+  }
+
+  try {
+    return JSON.parse(item) as T;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(`Failed to parse persistent item with key "${key}"`, error);
+
+    return fallback;
+  }
+};
+
+/**
+ * Set item in persistent storage and stringify it.
+ */
+export const setPersistentItem = (key: string, value: unknown): void => {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(`Failed to set persistent item with key "${key}"`, error);
+  }
+};

--- a/src/styleguide/demo-pages/general/r-page-settings-persistent.vue
+++ b/src/styleguide/demo-pages/general/r-page-settings-persistent.vue
@@ -1,0 +1,95 @@
+<template>
+  <l-vas-layout>
+    <template #pageConfig>
+      <e-vas-button
+        primary
+        @click="count++"
+      >
+        Button
+      </e-vas-button>
+      <e-vas-toggle v-model="toggleValue"> Toggle me </e-vas-toggle>
+    </template>
+
+    <div :class="b()">
+      <p>
+        This page shows you how to add custom settings and data to the `page-settings sidebar` and persist them. Open
+        the sidebar with the hotkey
+        <span class="l-vas-layout__highlight"><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>,</kbd></span>
+      </p>
+
+      <h4>How it works</h4>
+
+      <ul class="l-vas-layout__list">
+        <li>The state is initialized from a persistent storage if available.</li>
+        <li>A `watch` is used to save any changes back to the storage.</li>
+        <li>Try changing the values and then refresh the page.</li>
+      </ul>
+
+      <section :class="b('section')">
+        <c-vas-demo-card>
+          <template #header>Demo</template>
+          <template #demo>
+            <div>Button Click Count: {{ count }}</div>
+            <div>Toggle state {{ toggleValue ? 'On' : 'Off' }}</div>
+          </template>
+          <template #sidebar></template>
+        </c-vas-demo-card>
+      </section>
+    </div>
+  </l-vas-layout>
+</template>
+
+<script lang="ts">
+  import { defineComponent } from 'vue';
+  import { getPersistentItem, setPersistentItem } from '@/stores/helper';
+  import cVasDemoCard from '@/components/c-vas-demo-card.vue';
+  import eVasButton from '@/elements/e-vas-button.vue';
+  import eVasToggle from '@/elements/e-vas-toggle.vue';
+  import lVasLayout from '@/layouts/l-vas-layout.vue';
+
+  const STORAGE_KEY = 'vas-page-settings-persistent';
+
+  /**
+   * Styleguide page for persistent page settings.
+   */
+  export default defineComponent({
+    name: 'r-vas-page-settings-persistent',
+
+    components: {
+      eVasToggle,
+      cVasDemoCard,
+      eVasButton,
+      lVasLayout,
+    },
+
+    data() {
+      const defaults = {
+        count: 0,
+        toggleValue: false,
+      };
+
+      return {
+        ...defaults,
+        ...getPersistentItem(STORAGE_KEY, {}),
+      };
+    },
+
+    watch: {
+      count() {
+        this.saveSettings();
+      },
+      toggleValue() {
+        this.saveSettings();
+      },
+    },
+
+    methods: {
+      saveSettings() {
+        setPersistentItem(STORAGE_KEY, {
+          count: this.count,
+          toggleValue: this.toggleValue,
+        });
+      },
+    },
+  });
+</script>

--- a/src/styleguide/demo-pages/general/r-page-settings-persistent.vue
+++ b/src/styleguide/demo-pages/general/r-page-settings-persistent.vue
@@ -2,6 +2,12 @@
   <l-vas-layout>
     <template #pageConfig>
       <e-vas-button
+        style="margin-bottom: 50px"
+        @click="clearPersistentStore"
+      >
+        Reset persisted values
+      </e-vas-button>
+      <e-vas-button
         primary
         @click="count++"
       >
@@ -84,11 +90,24 @@
     },
 
     methods: {
+      /**
+       * Example of a save settings method.
+       */
       saveSettings() {
         setPersistentItem(STORAGE_KEY, {
           count: this.count,
           toggleValue: this.toggleValue,
         });
+      },
+
+      /**
+       * Example of a clear persisted data handler.
+       */
+      clearPersistentStore() {
+        this.count = 0;
+        this.toggleValue = false;
+
+        setPersistentItem(STORAGE_KEY, {});
       },
     },
   });

--- a/src/styleguide/demo-pages/general/r-page-settings-persistent.vue
+++ b/src/styleguide/demo-pages/general/r-page-settings-persistent.vue
@@ -53,7 +53,7 @@
   import eVasToggle from '@/elements/e-vas-toggle.vue';
   import lVasLayout from '@/layouts/l-vas-layout.vue';
 
-  const STORAGE_KEY = 'vas-page-settings-persistent';
+  const STORAGE_KEY = 'page-settings-persistent';
 
   /**
    * Styleguide page for persistent page settings.

--- a/src/styleguide/setup/routes.ts
+++ b/src/styleguide/setup/routes.ts
@@ -41,6 +41,15 @@ export default [
           alternativeTitles: ['Configuration', 'Mock'],
         },
       },
+      {
+        path: 'sg-test-page-settings-persistent',
+        name: 'sg-test-page-settings-persistent',
+        component: () => import('../demo-pages/general/r-page-settings-persistent.vue'),
+        meta: {
+          title: 'Page Settings Persistent',
+          alternativeTitles: ['Configuration', 'Mock', 'Persistence'],
+        },
+      },
     ],
   },
   {


### PR DESCRIPTION
## Pull request

Adds example and helper to persist page settings.

### Ticket / Issue

- https://github.com/valantic/vue-styleguide/issues/13

### Browser testing

- `npm run test` > works without errors
- `npm run dev`
- http://localhost:5173/sg/sg-test-page-settings-persistent

### Checklist

- [ ] I merged the current main branch (before testing)
- [ ] Added JSDoc and styleguide demo
- [ ] Did run automated tests and linters

## Review/Test checklist

- [ ] Did review code and documentation
