### PR TITLE
Feature/demo card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- [ENHANCEMENT] Add option to force the configuration to be on top of the demo card.
 - [ENHANCEMENT] Add the possibility to custom sort styleguide routes in the sidebar.
 
 ## v1.2.0

--- a/src/components/c-vas-demo-card.vue
+++ b/src/components/c-vas-demo-card.vue
@@ -69,6 +69,8 @@
   @use '../setup/scss/variables';
 
   .c-vas-demo-card {
+    $this: &;
+
     $content-padding: variables.$vas-spacing--16;
 
     border: 1px solid variables.$vas-theme-border-color;
@@ -91,10 +93,15 @@
     }
 
     &--force-configuration-top {
+      grid-template-columns: 1fr;
       grid-template-areas:
         'header'
-        'demo'
-        'sidebar';
+        'sidebar'
+        'demo';
+
+      #{$this}__sidebar {
+        border-bottom: 1px solid variables.$vas-theme-border-color;
+      }
     }
 
     &__header {

--- a/src/components/c-vas-demo-card.vue
+++ b/src/components/c-vas-demo-card.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="b()">
+  <div :class="b({ forceConfigurationTop })">
     <div :class="b('header')">
       <slot name="header"></slot>
     </div>
@@ -27,7 +27,15 @@
 
     // components: {},
 
-    // props: {},
+    props: {
+      /**
+       * If true, forces the configuration section to be placed above the demo section.
+       */
+      forceConfigurationTop: {
+        type: Boolean,
+        default: false,
+      },
+    },
     // emits: [],
 
     // setup(): Setup {
@@ -80,6 +88,13 @@
         'header header'
         'demo sidebar';
       grid-template-columns: 65% 35%;
+    }
+
+    &--force-configuration-top {
+      grid-template-areas:
+        'header'
+        'demo'
+        'sidebar';
     }
 
     &__header {

--- a/src/components/c-vas-demo-card.vue
+++ b/src/components/c-vas-demo-card.vue
@@ -101,6 +101,7 @@
 
       #{$this}__sidebar {
         border-bottom: 1px solid variables.$vas-theme-border-color;
+        border-left: none;
       }
     }
 

--- a/src/styleguide/demo-pages/components/r-vas-demo-card.vue
+++ b/src/styleguide/demo-pages/components/r-vas-demo-card.vue
@@ -1,8 +1,11 @@
 <template>
   <l-vas-layout>
+    <template #pageConfig>
+      <e-vas-toggle v-model="forceConfigurationTop"> Force configuration on top </e-vas-toggle>
+    </template>
     <div :class="b()">
       <section :class="b('section')">
-        <c-vas-demo-card>
+        <c-vas-demo-card :force-configuration-top="forceConfigurationTop">
           <template #header> Demo Card Header </template>
           <template #demo>
             <e-vas-button primary>Action</e-vas-button>
@@ -18,10 +21,13 @@
   import { defineComponent } from 'vue';
   import cVasDemoCard from '@/components/c-vas-demo-card.vue';
   import eVasButton from '@/elements/e-vas-button.vue';
+  import eVasToggle from '@/elements/e-vas-toggle.vue';
   import lVasLayout from '@/layouts/l-vas-layout.vue';
 
   // type Setup = {};
-  // type Data = {};
+  type Data = {
+    forceConfigurationTop: boolean;
+  };
 
   /**
    * Styleguide page for c-vas-demo-card.
@@ -30,6 +36,7 @@
     name: 'r-vas-demo-card',
 
     components: {
+      eVasToggle,
       cVasDemoCard,
       eVasButton,
       lVasLayout,
@@ -39,9 +46,11 @@
     // emits: {},
 
     // setup(): Setup {},
-    // data(): Data {
-    //   return {};
-    // },
+    data(): Data {
+      return {
+        forceConfigurationTop: false,
+      };
+    },
 
     // computed: {},
     // watch: {},


### PR DESCRIPTION
## Pull request

Updates demo card to support forcing sidebar on top for components which cannot deal with not having the full width.

### Browser testing

- `npm run test` > works without errors
- `npm run dev`
- http://localhost:5174/sg-components/sg-test-page-vas-demo-card

### Checklist

- [ ] I merged the current main branch (before testing)
- [ ] Added JSDoc and styleguide demo
- [ ] Did run automated tests and linters

## Review/Test checklist

- [ ] Did review code and documentation
