### PR TITLE
[Improvement] Sidebar Hotkeys Panels

### DIFF
--- a/src/components/c-vas-panel.vue
+++ b/src/components/c-vas-panel.vue
@@ -16,7 +16,7 @@
           tooltip="Settings"
           tooltip-position="bottom"
           :active="activePanel === 'settings'"
-          @click="activePanel = 'settings'"
+          @click="$emit('update:activePanel', 'settings')"
         />
       </div>
     </div>
@@ -29,7 +29,7 @@
           tooltip="Navigation"
           tooltip-position="right"
           :active="activePanel === 'navigation'"
-          @click="activePanel = 'navigation'"
+          @click="$emit('update:activePanel', 'navigation')"
         />
 
         <c-vas-panel-action
@@ -38,7 +38,7 @@
           tooltip="Global Configuration"
           tooltip-position="right"
           :active="activePanel === 'globalConfig'"
-          @click="activePanel = 'globalConfig'"
+          @click="$emit('update:activePanel', 'globalConfig')"
         />
 
         <c-vas-panel-action
@@ -50,7 +50,7 @@
           :disabled="!vasSessionStore.state.hasPageConfig"
           :badge="vasSessionStore.state.hasPageConfig"
           :highlighted="vasSessionStore.state.hasPageConfig"
-          @click="activePanel = 'pageConfig'"
+          @click="$emit('update:activePanel', 'pageConfig')"
         />
 
         <c-vas-panel-action
@@ -116,7 +116,7 @@
           tooltip="Features"
           tooltip-position="left"
           :active="activePanel === 'features'"
-          @click="activePanel = 'features'"
+          @click="$emit('update:activePanel', 'features')"
         />
       </div>
 
@@ -158,17 +158,13 @@
   import cVasTips from './c-vas-tips.vue';
   import cVasTypography from './c-vas-typography.vue';
 
-  type ActivePanel = 'navigation' | 'settings' | 'config' | 'globalConfig' | 'pageConfig' | 'features';
+  export type ActivePanel = 'navigation' | 'settings' | 'config' | 'globalConfig' | 'pageConfig' | 'features';
 
   type Setup = {
     router: ReturnType<typeof useRouter>;
     viewport: Viewport;
     vasSessionStore: VasSessionStore;
     bugReportUrl: string;
-  };
-
-  type Data = {
-    activePanel: ActivePanel;
   };
 
   /**
@@ -196,9 +192,19 @@
         type: Boolean,
         default: false,
       },
+
+      /**
+       * The currently active panel tab.
+       */
+      activePanel: {
+        type: String as () => ActivePanel,
+        required: true,
+      },
     },
     emits: {
       openHotkeysModal: () => true,
+      // ESLint disallows unused params, so we use `panel` in the body to satisfy the type checker.
+      'update:activePanel': (panel: ActivePanel) => !!panel,
     },
 
     setup(): Setup {
@@ -209,12 +215,6 @@
         bugReportUrl: packageJson.projectGitUrls.issues,
       };
     },
-    data(): Data {
-      return {
-        activePanel: 'navigation',
-      };
-    },
-
     computed: {
       viewPortTooltip(): string {
         return `Viewport: ${this.viewport.viewportWidth}w / ${this.viewport.viewportHeight}h`;

--- a/src/components/c-vas-sidebar.vue
+++ b/src/components/c-vas-sidebar.vue
@@ -265,7 +265,7 @@
         }
 
         // Hotkeys for tab switching.
-        if ((isMac() ? event.metaKey : event.ctrlKey) && !event.shiftKey && event.key === '1') {
+        if (event.ctrlKey && !event.shiftKey && event.key === '1') {
           event.preventDefault();
           this.onToggleMainFlyout(true);
           this.activePanel = 'navigation';
@@ -273,7 +273,7 @@
           return;
         }
 
-        if ((isMac() ? event.metaKey : event.ctrlKey) && !event.shiftKey && event.key === '2') {
+        if (event.ctrlKey && !event.shiftKey && event.key === '2') {
           event.preventDefault();
           this.onToggleMainFlyout(true);
           this.activePanel = 'globalConfig';
@@ -282,7 +282,7 @@
         }
 
         if (
-          (isMac() ? event.metaKey : event.ctrlKey) &&
+          event.ctrlKey &&
           !event.shiftKey &&
           event.key === '3' &&
           this.vasSessionStore.state.hasPageConfig

--- a/src/components/c-vas-sidebar.vue
+++ b/src/components/c-vas-sidebar.vue
@@ -19,6 +19,7 @@
 
       <template #content>
         <c-vas-panel
+          v-model:active-panel="activePanel"
           :is-open="isMainFlyoutOpen"
           @open-hotkeys-modal="isHotkeysModalOpen = true"
         >
@@ -49,7 +50,7 @@
   import cVasFlyoutHandle from './c-vas-flyout-handle.vue';
   import cVasFlyout from './c-vas-flyout.vue';
   import cVasHotkeyModal from './c-vas-hotkey-modal.vue';
-  import cVasPanel from './c-vas-panel.vue';
+  import cVasPanel, { type ActivePanel } from './c-vas-panel.vue';
 
   const DOUBLE_SHIFT_DELAY_MS = 500;
   const PAGE_CONFIG_ANIMATION_DURATION_MS = 600;
@@ -71,6 +72,7 @@
   type Data = {
     isMainFlyoutOpen: boolean;
     isHotkeysModalOpen: boolean;
+    activePanel: ActivePanel;
     lastShiftPress: number;
     isToggleButtonAnimated: boolean;
     animationTimeout: ReturnType<typeof setTimeout> | null;
@@ -103,6 +105,7 @@
       return {
         isMainFlyoutOpen: false,
         isHotkeysModalOpen: false,
+        activePanel: 'navigation',
         lastShiftPress: 0,
         isToggleButtonAnimated: false,
         animationTimeout: null,
@@ -257,6 +260,36 @@
         if ((isMac() ? event.metaKey : event.ctrlKey) && event.shiftKey && event.key === 'o') {
           event.preventDefault();
           this.onToggleMainFlyout();
+
+          return;
+        }
+
+        // Hotkeys for tab switching.
+        if ((isMac() ? event.metaKey : event.ctrlKey) && !event.shiftKey && event.key === '1') {
+          event.preventDefault();
+          this.onToggleMainFlyout(true);
+          this.activePanel = 'navigation';
+
+          return;
+        }
+
+        if ((isMac() ? event.metaKey : event.ctrlKey) && !event.shiftKey && event.key === '2') {
+          event.preventDefault();
+          this.onToggleMainFlyout(true);
+          this.activePanel = 'globalConfig';
+
+          return;
+        }
+
+        if (
+          (isMac() ? event.metaKey : event.ctrlKey) &&
+          !event.shiftKey &&
+          event.key === '3' &&
+          this.vasSessionStore.state.hasPageConfig
+        ) {
+          event.preventDefault();
+          this.onToggleMainFlyout(true);
+          this.activePanel = 'pageConfig';
 
           return;
         }

--- a/src/config/hotkeys.ts
+++ b/src/config/hotkeys.ts
@@ -45,30 +45,18 @@ export const HOTKEYS: HotkeyEntry[] = [
     tip: 'Ctrl + 1 — Navigation tab',
     description: 'Open the sidebar and switch to the Navigation tab.',
     display: [['Ctrl', '+', '1']],
-    mac: {
-      tip: '⌘ + 1 — Navigation tab',
-      display: [['⌘', '+', '1']],
-    },
   },
   {
     id: 'tab-global-config',
     tip: 'Ctrl + 2 — Global Config tab',
     description: 'Open the sidebar and switch to the Global Configuration tab.',
     display: [['Ctrl', '+', '2']],
-    mac: {
-      tip: '⌘ + 2 — Global Config tab',
-      display: [['⌘', '+', '2']],
-    },
   },
   {
     id: 'tab-page-config',
     tip: 'Ctrl + 3 — Page Config tab',
     description: 'Open the sidebar and switch to the Page Configuration tab (only when available).',
     display: [['Ctrl', '+', '3']],
-    mac: {
-      tip: '⌘ + 3 — Page Config tab',
-      display: [['⌘', '+', '3']],
-    },
   },
   {
     id: 'navigate-vertical',

--- a/src/config/hotkeys.ts
+++ b/src/config/hotkeys.ts
@@ -27,17 +27,47 @@ export const HOTKEYS: HotkeyEntry[] = [
   {
     id: 'toggle-double-shift',
     tip: '⇧ + ⇧ — toggle sidebar',
-    description: 'Toggle the styleguide sidebar. Opens the sidebar with the navigation tab preselected.',
+    description: 'Toggle the styleguide sidebar. Opens the sidebar with the last active tab preselected.',
     display: [['Shift'], ['Shift']],
   },
   {
     id: 'toggle-cmd-shift-o',
     tip: 'Ctrl + Shift + O — toggle sidebar',
-    description: 'Toggle the styleguide sidebar. Opens the sidebar with the navigation tab preselected.',
+    description: 'Toggle the styleguide sidebar. Opens the sidebar with the last active tab preselected.',
     display: [['Ctrl', '+', 'Shift', '+', 'O']],
     mac: {
       tip: '⌘ + ⇧ + O — toggle sidebar',
       display: [['⌘', '+', 'Shift', '+', 'O']],
+    },
+  },
+  {
+    id: 'tab-navigation',
+    tip: 'Ctrl + 1 — Navigation tab',
+    description: 'Open the sidebar and switch to the Navigation tab.',
+    display: [['Ctrl', '+', '1']],
+    mac: {
+      tip: '⌘ + 1 — Navigation tab',
+      display: [['⌘', '+', '1']],
+    },
+  },
+  {
+    id: 'tab-global-config',
+    tip: 'Ctrl + 2 — Global Config tab',
+    description: 'Open the sidebar and switch to the Global Configuration tab.',
+    display: [['Ctrl', '+', '2']],
+    mac: {
+      tip: '⌘ + 2 — Global Config tab',
+      display: [['⌘', '+', '2']],
+    },
+  },
+  {
+    id: 'tab-page-config',
+    tip: 'Ctrl + 3 — Page Config tab',
+    description: 'Open the sidebar and switch to the Page Configuration tab (only when available).',
+    display: [['Ctrl', '+', '3']],
+    mac: {
+      tip: '⌘ + 3 — Page Config tab',
+      display: [['⌘', '+', '3']],
     },
   },
   {

--- a/src/styleguide/demo-pages/components/r-vas-panel.vue
+++ b/src/styleguide/demo-pages/components/r-vas-panel.vue
@@ -4,18 +4,22 @@
       :class="b('preview')"
       class="vas-styleguide-theme-dark"
     >
-      <c-vas-panel />
+      <c-vas-panel
+        v-model:active-panel="activePanel"
+      />
     </div>
   </l-vas-layout>
 </template>
 
 <script lang="ts">
   import { defineComponent } from 'vue';
-  import cVasPanel from '../../../components/c-vas-panel.vue';
+  import cVasPanel, { type ActivePanel } from '../../../components/c-vas-panel.vue';
   import lVasLayout from '../../../layouts/l-vas-layout.vue';
 
   // type Setup = {};
-  // type Data = {};
+  type Data = {
+    activePanel: ActivePanel;
+  };
 
   /**
    * Styleguide page for c-vas-panel.
@@ -34,9 +38,11 @@
     // setup(): Setup {
     //   return {};
     // },
-    // data(): Data {
-    //   return {};
-    // },
+    data(): Data {
+      return {
+        activePanel: 'navigation',
+      };
+    },
 
     // computed: {},
     // watch: {},

--- a/tests/unit/specs/components/c-vas-sidebar.test.ts
+++ b/tests/unit/specs/components/c-vas-sidebar.test.ts
@@ -1,0 +1,95 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import cVasSidebar from '../../../../src/components/c-vas-sidebar.vue';
+import vueBemCn from '../../../../src/plugins/vue-bem-cn';
+import { useVasSessionStore } from '../../../../src/stores/session';
+
+window.matchMedia = vi.fn().mockReturnValue({
+  matches: false,
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+});
+
+type SidebarVm = {
+  isMainFlyoutOpen: boolean;
+  activePanel: string;
+};
+
+const mountSidebar = () =>
+  mount(cVasSidebar, {
+    global: {
+      plugins: [vueBemCn],
+      stubs: {
+        'c-vas-flyout': true,
+        'c-vas-flyout-handle': true,
+        'c-vas-hotkey-modal': true,
+        'c-vas-panel': true,
+      },
+    },
+    attachTo: document.body,
+  });
+
+describe('c-vas-sidebar', () => {
+  let wrapper: ReturnType<typeof mountSidebar>;
+
+  afterEach(() => {
+    wrapper?.unmount();
+    useVasSessionStore().setHasPageConfig(false);
+    vi.restoreAllMocks();
+  });
+
+  describe('tab-switching hotkeys', () => {
+    test('Ctrl+1 opens the flyout and switches to the navigation tab', async () => {
+      wrapper = mountSidebar();
+      await wrapper.vm.$nextTick();
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: '1', ctrlKey: true, bubbles: true }));
+      await wrapper.vm.$nextTick();
+
+      const vm = wrapper.vm as unknown as SidebarVm;
+
+      expect(vm.isMainFlyoutOpen).toBe(true);
+      expect(vm.activePanel).toBe('navigation');
+    });
+
+    test('Ctrl+2 opens the flyout and switches to the globalConfig tab', async () => {
+      wrapper = mountSidebar();
+      await wrapper.vm.$nextTick();
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: '2', ctrlKey: true, bubbles: true }));
+      await wrapper.vm.$nextTick();
+
+      const vm = wrapper.vm as unknown as SidebarVm;
+
+      expect(vm.isMainFlyoutOpen).toBe(true);
+      expect(vm.activePanel).toBe('globalConfig');
+    });
+
+    test('Ctrl+3 opens the flyout and switches to the pageConfig tab when hasPageConfig is true', async () => {
+      useVasSessionStore().setHasPageConfig(true);
+      wrapper = mountSidebar();
+      await wrapper.vm.$nextTick();
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: '3', ctrlKey: true, bubbles: true }));
+      await wrapper.vm.$nextTick();
+
+      const vm = wrapper.vm as unknown as SidebarVm;
+
+      expect(vm.isMainFlyoutOpen).toBe(true);
+      expect(vm.activePanel).toBe('pageConfig');
+    });
+
+    test('Ctrl+3 does nothing when hasPageConfig is false', async () => {
+      wrapper = mountSidebar();
+      await wrapper.vm.$nextTick();
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: '3', ctrlKey: true, bubbles: true }));
+      await wrapper.vm.$nextTick();
+
+      const vm = wrapper.vm as unknown as SidebarVm;
+
+      expect(vm.isMainFlyoutOpen).toBe(false);
+      expect(vm.activePanel).toBe('navigation');
+    });
+  });
+});


### PR DESCRIPTION
## Pull request

Adds Hotkeys for Switching between `Navigation` `Global Configuration` and `Page Configuration` Panels in `c-vas-panel`

### Ticket / Issue

- NO JIRA

### Browser testing

- `npm run test` > works without errors
- `npm run dev`
- http://localhost:5174/sg/features/sg-test-page-vas-demo-card
- Open Panel `shift + shift`
- Toggle between Panels `CTRL + 1` `CTRL + 2` `CTRL +3`

### Checklist

- [ ] I merged the current main branch (before testing)
- [ ] Added JSDoc and styleguide demo
- [ ] Did run automated tests and linters

## Review/Test checklist

- [ ] Did review code and documentation
