### PR TITLE
Feature/xray

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,5 +28,11 @@ Only four things are exported for consumer projects:
 - Always import with `@use '../setup/scss/variables'` and `@use '../setup/scss/mixins'` (namespaced, not `@import`)
 - The `vas-styleguide-reset` CSS reset wrapper is applied at the root of `c-vas-sidebar` to scope the reset
 
+### Production safety is the consumer's responsibility
+- This package ships raw, uncompiled source — `package.json`'s `main`/`module`/`exports` point directly at `src/index.ts`, there is no separate build/dist step for npm distribution. A consumer's own Vite/Rollup build processes these files exactly like first-party source, so whatever survives *their* tree-shaking ends up in *their* bundle.
+- `c-vas-sidebar` and every feature registered under it (`c-vas-features.vue`, e.g. `c-vas-html-validation`, `c-vas-x-ray-mode`) are wired together via ordinary static imports. Nothing in this package internally gates itself behind `import.meta.env.DEV` — there is no bundling boundary here to strip dev-only code from.
+- It is the **consuming project's** job to keep this out of production, e.g. by guarding its own usage of `c-vas-sidebar` (and any exported plugin, such as `vasXRayInspector`) behind `import.meta.env.DEV` — ideally via a dynamic `import()` for a stronger guarantee than relying on tree-shaking alone (see `docs/x-ray-mode.md` for a worked example, and this package's own `src/main.ts` for the same pattern used internally).
+- Don't add dev-only guards inside this package's own components/features to compensate for a consumer skipping that step — that responsibility intentionally lives in the consumer's app entry, not here.
+
 ### Testing
 - For all tasks, run all tests with `npm run test` and always fix the issues.

--- a/docs/x-ray-mode.md
+++ b/docs/x-ray-mode.md
@@ -1,10 +1,11 @@
 # X-ray mode
 
 X-ray mode is a hover inspector built into the styleguide sidebar. Turn it on (Features panel, or
-`Ctrl + Alt + X` / `⌘ + ⌥ + X` on Mac), then hover any element on the page to see the name and
-source file of the Vue component it belongs to — click to copy its file path (project-relative,
-e.g. `src/components/UserCard.vue`) to your clipboard, ready to paste into an AI coding prompt. If
-no file path can be resolved, the component (or DOM tag) name is copied instead.
+`Ctrl + Alt + X` / `⌘ + ⌥ + X` on Mac) — a brief toast in the top-right corner confirms it's now on
+or off, however you toggled it — then hover any element on the page to see the name and source
+file of the Vue component it belongs to — click to copy its file path (project-relative, e.g.
+`src/components/UserCard.vue`) to your clipboard, ready to paste into an AI coding prompt. If no
+file path can be resolved, the component (or DOM tag) name is copied instead.
 
 ## Setup (recommended)
 
@@ -66,9 +67,11 @@ own). While hovering:
 
 - **Alt + ↑** (`⌥ + ↑` on Mac) — select the parent component (step outward).
 - **Alt + ↓** (`⌥ + ↓` on Mac) — select the child component again (step back inward).
+- **Enter** — copy the currently selected component, same as clicking it.
 
 The label shows a `2/5`-style counter whenever there's more than one component to step through.
-Clicking always copies whichever entry is currently selected.
+Together with Enter, the whole hover → navigate → copy flow can stay on the keyboard once the
+mouse has picked a starting element.
 
 ## Limitations
 

--- a/docs/x-ray-mode.md
+++ b/docs/x-ray-mode.md
@@ -8,16 +8,19 @@ clipboard, ready to paste into an AI coding prompt.
 ## Setup (recommended)
 
 X-ray mode works out of the box with zero configuration, but its accuracy is limited without one
-extra step: register the `vasXRayInspector` plugin once, before `app.mount()`.
+extra step: register the `vasXRayInspector` plugin once, before `app.mount()`. Import it
+dynamically inside a dev-only check — the same pattern this package's own `main.ts` uses for its
+dev-only setup — so it's never even requested in a production build:
 
 ```js
-import { vasXRayInspector } from '@valantic/vue-styleguide';
 import { createApp } from 'vue';
 import App from './App.vue';
 
 const app = createApp(App);
 
 if (import.meta.env.DEV) {
+  const { vasXRayInspector } = await import('@valantic/vue-styleguide');
+
   app.use(vasXRayInspector);
 }
 
@@ -26,6 +29,11 @@ app.mount('#app');
 
 If you see a warning under the "X-ray mode" toggle in the Features panel, this step is missing (or
 was registered on a different app instance than the one the sidebar is mounted in).
+
+Note this only guards the plugin's own registration. The x-ray overlay UI itself is a `c-vas-sidebar`
+feature, wired up the same way every other feature (e.g. HTML validation) already is — whether it
+(and the rest of the sidebar) reaches a production bundle depends on how you guard your own use of
+`c-vas-sidebar`, not on this plugin.
 
 ## Why this step is needed
 

--- a/docs/x-ray-mode.md
+++ b/docs/x-ray-mode.md
@@ -1,9 +1,10 @@
 # X-ray mode
 
 X-ray mode is a hover inspector built into the styleguide sidebar. Turn it on (Features panel, or
-`Ctrl/⌘ + Shift + X`), then hover any element on the page to see the name and source file of the
-Vue component it belongs to — click to copy `ComponentName (src/path/to/File.vue)` to your
-clipboard, ready to paste into an AI coding prompt.
+`Ctrl + Alt + X` / `⌘ + ⌥ + X` on Mac), then hover any element on the page to see the name and
+source file of the Vue component it belongs to — click to copy its file path (project-relative,
+e.g. `src/components/UserCard.vue`) to your clipboard, ready to paste into an AI coding prompt. If
+no file path can be resolved, the component (or DOM tag) name is copied instead.
 
 ## Setup (recommended)
 
@@ -63,8 +64,8 @@ Once the plugin is installed, hovering an element resolves its full chain of mar
 skipping every plain DOM node in between (divs, spans, layout wrappers with no component of their
 own). While hovering:
 
-- **Alt + ↑** — select the parent component (step outward).
-- **Alt + ↓** — select the child component again (step back inward).
+- **Alt + ↑** (`⌥ + ↑` on Mac) — select the parent component (step outward).
+- **Alt + ↓** (`⌥ + ↓` on Mac) — select the child component again (step back inward).
 
 The label shows a `2/5`-style counter whenever there's more than one component to step through.
 Clicking always copies whichever entry is currently selected.
@@ -73,8 +74,10 @@ Clicking always copies whichever entry is currently selected.
 
 - `__file` (used for the source path) is only available in dev builds and is an absolute
   filesystem path — it's trimmed to start at the last `/src/` segment as a best-effort guess at a
-  project-relative path. This won't be accurate for projects that don't root their source in a
-  `src/` folder.
+  project-relative path. If that marker can't be found (e.g. your project doesn't root its source
+  in a `src/` folder), the path is treated as unresolvable rather than copying the raw absolute
+  path — the component (or DOM tag) name is copied instead, so a full local filesystem path never
+  ends up on your clipboard.
 - Components with no resolvable name at all (no explicit `name`, and no compiler-injected
   `__name` — effectively only hand-written, non-SFC render functions) can't be identified and are
   skipped.

--- a/docs/x-ray-mode.md
+++ b/docs/x-ray-mode.md
@@ -1,0 +1,72 @@
+# X-ray mode
+
+X-ray mode is a hover inspector built into the styleguide sidebar. Turn it on (Features panel, or
+`Ctrl/⌘ + Shift + X`), then hover any element on the page to see the name and source file of the
+Vue component it belongs to — click to copy `ComponentName (src/path/to/File.vue)` to your
+clipboard, ready to paste into an AI coding prompt.
+
+## Setup (recommended)
+
+X-ray mode works out of the box with zero configuration, but its accuracy is limited without one
+extra step: register the `vasXRayInspector` plugin once, before `app.mount()`.
+
+```js
+import { vasXRayInspector } from '@valantic/vue-styleguide';
+import { createApp } from 'vue';
+import App from './App.vue';
+
+const app = createApp(App);
+
+if (import.meta.env.DEV) {
+  app.use(vasXRayInspector);
+}
+
+app.mount('#app');
+```
+
+If you see a warning under the "X-ray mode" toggle in the Features panel, this step is missing (or
+was registered on a different app instance than the one the sidebar is mounted in).
+
+## Why this step is needed
+
+Without the plugin, x-ray mode falls back to reading Vue's internal `__vueParentComponent`
+reference, which only ever reflects the single deepest component sharing a given DOM node. That
+breaks down in two common cases:
+
+- **Wrapping a component without adding a wrapping element.** If your `e-button.vue` renders
+  `<v-btn>` (or any other library component) as its template root with no extra `<div>`, both
+  components share the exact same root DOM element, and Vue's internal reference only remembers
+  the innermost one — you'd see `VBtn` instead of `e-button`.
+- **Generic containers.** Hovering something whose nearest *real* component genuinely is a
+  structural wrapper (a layout `Section`, a `VCol`) will show that wrapper, not a more
+  "interesting" ancestor several DOM levels further up — because that ancestor is a different DOM
+  node entirely, not something a single-node lookup can see.
+
+The plugin fixes this by registering a global [mixin](https://vuejs.org/guide/reusability/composables.html)
+that marks every component's root DOM element with its own name and source file as it mounts.
+Because it's a *global* mixin, it applies to every component the app creates — including
+third-party ones (Vuetify, PrimeVue, etc.), since they're mounted by the same app instance. That
+gives x-ray mode an accurate marker at every real component boundary, letting it build a clean,
+component-only ancestor chain instead of guessing from a single undocumented internal.
+
+## Navigating the ancestor chain
+
+Once the plugin is installed, hovering an element resolves its full chain of marked ancestors —
+skipping every plain DOM node in between (divs, spans, layout wrappers with no component of their
+own). While hovering:
+
+- **Alt + ↑** — select the parent component (step outward).
+- **Alt + ↓** — select the child component again (step back inward).
+
+The label shows a `2/5`-style counter whenever there's more than one component to step through.
+Clicking always copies whichever entry is currently selected.
+
+## Limitations
+
+- `__file` (used for the source path) is only available in dev builds and is an absolute
+  filesystem path — it's trimmed to start at the last `/src/` segment as a best-effort guess at a
+  project-relative path. This won't be accurate for projects that don't root their source in a
+  `src/` folder.
+- Components with no resolvable name at all (no explicit `name`, and no compiler-injected
+  `__name` — effectively only hand-written, non-SFC render functions) can't be identified and are
+  skipped.

--- a/src/components/c-vas-features.vue
+++ b/src/components/c-vas-features.vue
@@ -5,12 +5,14 @@
       text="Features"
     />
     <c-vas-html-validation />
+    <c-vas-x-ray-mode />
   </div>
 </template>
 
 <script lang="ts">
   import { defineComponent } from 'vue';
   import cVasHtmlValidation from '../features/c-vas-html-validation.vue';
+  import cVasXRayMode from '../features/c-vas-x-ray-mode.vue';
   import cVasTypography from './c-vas-typography.vue';
 
   // type Setup = {};
@@ -24,6 +26,7 @@
 
     components: {
       cVasHtmlValidation,
+      cVasXRayMode,
       cVasTypography,
     },
 

--- a/src/components/c-vas-sidebar.vue
+++ b/src/components/c-vas-sidebar.vue
@@ -35,6 +35,7 @@
     <c-vas-hotkey-modal :is-open="isHotkeysModalOpen" />
 
     <c-vas-x-ray-overlay v-if="vasSettingsStore.state.isXRayModeEnabled" />
+    <c-vas-x-ray-toast />
   </div>
 </template>
 
@@ -53,6 +54,7 @@
   import cVasHotkeyModal from './c-vas-hotkey-modal.vue';
   import cVasPanel from './c-vas-panel.vue';
   import cVasXRayOverlay from './c-vas-x-ray-overlay.vue';
+  import cVasXRayToast from './c-vas-x-ray-toast.vue';
 
   const DOUBLE_SHIFT_DELAY_MS = 500;
   const PAGE_CONFIG_ANIMATION_DURATION_MS = 600;
@@ -63,6 +65,7 @@
     shiftKey: boolean;
     altKey: boolean;
     key: string;
+    code: string;
   };
 
   type Setup = {
@@ -90,6 +93,7 @@
       cVasHotkeyModal,
       cVasPanel,
       cVasXRayOverlay,
+      cVasXRayToast,
     },
     // props: {},
 
@@ -250,10 +254,14 @@
         // Reset the Shift timer on any other key press.
         this.lastShiftPress = 0;
 
-        // ESC for all flyout.
+        // ESC for all flyout, and also turns off x-ray mode if it's currently on.
         if (event.key === 'Escape') {
           event.preventDefault();
           this.onCloseFlyout();
+
+          if (this.vasSettingsStore.state.isXRayModeEnabled) {
+            this.vasSettingsStore.setXRayModeEnabled(false);
+          }
 
           return;
         }
@@ -268,7 +276,9 @@
 
         // Hotkey for x-ray mode. Uses Alt/Option rather than Shift — Ctrl/Cmd+Shift+X collides
         // with the default shortcut of some password manager browser extensions (e.g. 1Password).
-        if ((isMac() ? event.metaKey : event.ctrlKey) && event.altKey && event.key.toLowerCase() === 'x') {
+        // Checks `event.code` (the physical key), not `event.key`: on Mac, holding Option remaps
+        // the produced character (Option+X types "≈", not "x"), so `event.key` never matches.
+        if ((isMac() ? event.metaKey : event.ctrlKey) && event.altKey && event.code === 'KeyX') {
           event.preventDefault();
           this.vasSettingsStore.setXRayModeEnabled(!this.vasSettingsStore.state.isXRayModeEnabled);
 

--- a/src/components/c-vas-sidebar.vue
+++ b/src/components/c-vas-sidebar.vue
@@ -61,6 +61,7 @@
     metaKey: boolean;
     ctrlKey: boolean;
     shiftKey: boolean;
+    altKey: boolean;
     key: string;
   };
 
@@ -265,8 +266,9 @@
           return;
         }
 
-        // Hotkey for x-ray mode.
-        if ((isMac() ? event.metaKey : event.ctrlKey) && event.shiftKey && event.key.toLowerCase() === 'x') {
+        // Hotkey for x-ray mode. Uses Alt/Option rather than Shift — Ctrl/Cmd+Shift+X collides
+        // with the default shortcut of some password manager browser extensions (e.g. 1Password).
+        if ((isMac() ? event.metaKey : event.ctrlKey) && event.altKey && event.key.toLowerCase() === 'x') {
           event.preventDefault();
           this.vasSettingsStore.setXRayModeEnabled(!this.vasSettingsStore.state.isXRayModeEnabled);
 

--- a/src/components/c-vas-sidebar.vue
+++ b/src/components/c-vas-sidebar.vue
@@ -33,6 +33,8 @@
     </c-vas-flyout>
 
     <c-vas-hotkey-modal :is-open="isHotkeysModalOpen" />
+
+    <c-vas-x-ray-overlay v-if="vasSettingsStore.state.isXRayModeEnabled" />
   </div>
 </template>
 
@@ -50,6 +52,7 @@
   import cVasFlyout from './c-vas-flyout.vue';
   import cVasHotkeyModal from './c-vas-hotkey-modal.vue';
   import cVasPanel from './c-vas-panel.vue';
+  import cVasXRayOverlay from './c-vas-x-ray-overlay.vue';
 
   const DOUBLE_SHIFT_DELAY_MS = 500;
   const PAGE_CONFIG_ANIMATION_DURATION_MS = 600;
@@ -85,6 +88,7 @@
       cVasFlyout,
       cVasHotkeyModal,
       cVasPanel,
+      cVasXRayOverlay,
     },
     // props: {},
 
@@ -257,6 +261,14 @@
         if ((isMac() ? event.metaKey : event.ctrlKey) && event.shiftKey && event.key === 'o') {
           event.preventDefault();
           this.onToggleMainFlyout();
+
+          return;
+        }
+
+        // Hotkey for x-ray mode.
+        if ((isMac() ? event.metaKey : event.ctrlKey) && event.shiftKey && event.key.toLowerCase() === 'x') {
+          event.preventDefault();
+          this.vasSettingsStore.setXRayModeEnabled(!this.vasSettingsStore.state.isXRayModeEnabled);
 
           return;
         }

--- a/src/components/c-vas-x-ray-overlay.vue
+++ b/src/components/c-vas-x-ray-overlay.vue
@@ -1,25 +1,29 @@
 <template>
   <div :class="b()">
-    <template v-if="target">
+    <template v-if="current">
       <div
-        :class="b('box', { unresolved: !hasComponent })"
+        :class="b('box', { unresolved: !current.hasComponent })"
         :style="boxStyle"
       ></div>
       <div
-        :class="b('label', { unresolved: !hasComponent, copied })"
+        :class="b('label', { unresolved: !current.hasComponent, copied })"
         :style="labelStyle"
       >
         <template v-if="copied">Copied!</template>
         <template v-else>
-          <span :class="b('name')">{{ label }}</span>
+          <span :class="b('name')">{{ current.name }}</span>
           <span
-            v-if="filePath"
+            v-if="current.file"
             :class="b('path')"
-          >{{ filePath }}</span>
+          >{{ current.file }}</span>
           <span
-            v-if="wraps"
+            v-if="current.wraps"
             :class="b('wraps')"
-          >wraps {{ wraps }}</span>
+          >wraps {{ current.wraps }}</span>
+          <span
+            v-if="depthHint"
+            :class="b('depth')"
+          >{{ depthHint }} · Alt+↑/↓</span>
         </template>
       </div>
     </template>
@@ -28,17 +32,22 @@
 
 <script lang="ts">
   import { defineComponent } from 'vue';
-  import { formatCopyText, resolveComponentAtElement } from '../utils/vue-component-inspector';
+  import { formatCopyText, getComponentBreadcrumb } from '../utils/vue-component-inspector';
 
   // type Setup = {};
 
-  type Data = {
-    target: Element | null;
-    hasComponent: boolean;
-    label: string;
-    filePath: string | null;
+  type DisplayEntry = {
+    el: Element;
+    name: string;
+    file: string | null;
     wraps: string | null;
-    copyText: string;
+    hasComponent: boolean;
+  };
+
+  type Data = {
+    breadcrumb: DisplayEntry[];
+    selectedIndex: number;
+    hoveredEl: Element | null;
     copied: boolean;
     copiedTimeout: ReturnType<typeof setTimeout> | null;
     frame: number | null;
@@ -49,8 +58,9 @@
   const COPIED_FEEDBACK_MS = 1200;
 
   /**
-   * Full-viewport hover inspector for x-ray mode: highlights the Vue component under the
-   * cursor and copies its name + file path to the clipboard on click.
+   * Full-viewport hover inspector for x-ray mode: highlights the Vue component under the cursor,
+   * lets you step through its component-only ancestor chain (Alt+↑ parent / Alt+↓ child) — skipping
+   * every plain DOM node in between — and copies the selected one's name + file path on click.
    */
   export default defineComponent({
     name: 'c-vas-x-ray-overlay',
@@ -65,12 +75,9 @@
     // },
     data(): Data {
       return {
-        target: null,
-        hasComponent: false,
-        label: '',
-        filePath: null,
-        wraps: null,
-        copyText: '',
+        breadcrumb: [],
+        selectedIndex: 0,
+        hoveredEl: null,
         copied: false,
         copiedTimeout: null,
         frame: null,
@@ -78,6 +85,26 @@
     },
 
     computed: {
+      current(): DisplayEntry | null {
+        if (this.breadcrumb.length > 0) {
+          return this.breadcrumb[this.selectedIndex] ?? this.breadcrumb[0] ?? null;
+        }
+
+        if (!this.hoveredEl) {
+          return null;
+        }
+
+        return { el: this.hoveredEl, name: `<${this.hoveredEl.tagName.toLowerCase()}>`, file: null, wraps: null, hasComponent: false };
+      },
+
+      depthHint(): string | null {
+        return this.breadcrumb.length > 1 ? `${this.selectedIndex + 1}/${this.breadcrumb.length}` : null;
+      },
+
+      copyText(): string {
+        return this.current ? formatCopyText(this.current) : '';
+      },
+
       boxStyle(): Record<string, string> {
         return this.rectStyle(0);
       },
@@ -94,6 +121,7 @@
     mounted() {
       document.addEventListener('mousemove', this.handleMouseMove);
       document.addEventListener('click', this.handleClick, { capture: true });
+      document.addEventListener('keydown', this.handleKeyDown);
     },
     // beforeUpdate() {},
     // updated() {},
@@ -102,6 +130,7 @@
     beforeUnmount() {
       document.removeEventListener('mousemove', this.handleMouseMove);
       document.removeEventListener('click', this.handleClick, { capture: true });
+      document.removeEventListener('keydown', this.handleKeyDown);
 
       if (this.frame !== null) {
         cancelAnimationFrame(this.frame);
@@ -115,11 +144,11 @@
 
     methods: {
       rectStyle(topOffset: number): Record<string, string> {
-        if (!this.target) {
+        if (!this.current) {
           return {};
         }
 
-        const rect = this.target.getBoundingClientRect();
+        const rect = this.current.el.getBoundingClientRect();
 
         return {
           top: `${rect.top + topOffset}px`,
@@ -146,30 +175,35 @@
 
       updateTarget(el: Element | null): void {
         if (!el || this.isSidebarChrome(el)) {
-          this.target = null;
+          this.breadcrumb = [];
+          this.hoveredEl = null;
 
           return;
         }
 
-        const resolved = resolveComponentAtElement(el);
-
-        if (resolved) {
-          this.target = resolved.el;
-          this.hasComponent = true;
-          this.label = resolved.name;
-          this.filePath = resolved.file;
-          this.wraps = resolved.wraps;
-          this.copyText = formatCopyText(resolved);
-
+        // Same leaf DOM node as last time — keep the current selection (which may have been
+        // navigated away from the nearest match via Alt+↑/↓) instead of resetting it every frame.
+        if (el === this.hoveredEl) {
           return;
         }
 
-        this.target = el;
-        this.hasComponent = false;
-        this.label = `<${el.tagName.toLowerCase()}>`;
-        this.filePath = null;
-        this.wraps = null;
-        this.copyText = this.label;
+        this.hoveredEl = el;
+        this.breadcrumb = getComponentBreadcrumb(el).map((resolved) => ({ ...resolved, hasComponent: true }));
+        this.selectedIndex = 0;
+      },
+
+      handleKeyDown(event: KeyboardEvent): void {
+        if (!event.altKey || this.breadcrumb.length < 2) {
+          return;
+        }
+
+        if (event.key === 'ArrowUp') {
+          event.preventDefault();
+          this.selectedIndex = Math.min(this.selectedIndex + 1, this.breadcrumb.length - 1);
+        } else if (event.key === 'ArrowDown') {
+          event.preventDefault();
+          this.selectedIndex = Math.max(this.selectedIndex - 1, 0);
+        }
       },
 
       handleClick(event: MouseEvent): void {
@@ -253,7 +287,8 @@
     }
 
     &__path,
-    &__wraps {
+    &__wraps,
+    &__depth {
       font-weight: normal;
       opacity: 0.85;
     }

--- a/src/components/c-vas-x-ray-overlay.vue
+++ b/src/components/c-vas-x-ray-overlay.vue
@@ -16,6 +16,10 @@
             v-if="filePath"
             :class="b('path')"
           >{{ filePath }}</span>
+          <span
+            v-if="wraps"
+            :class="b('wraps')"
+          >wraps {{ wraps }}</span>
         </template>
       </div>
     </template>
@@ -33,6 +37,7 @@
     hasComponent: boolean;
     label: string;
     filePath: string | null;
+    wraps: string | null;
     copyText: string;
     copied: boolean;
     copiedTimeout: ReturnType<typeof setTimeout> | null;
@@ -64,6 +69,7 @@
         hasComponent: false,
         label: '',
         filePath: null,
+        wraps: null,
         copyText: '',
         copied: false,
         copiedTimeout: null,
@@ -152,6 +158,7 @@
           this.hasComponent = true;
           this.label = resolved.name;
           this.filePath = resolved.file;
+          this.wraps = resolved.wraps;
           this.copyText = formatCopyText(resolved);
 
           return;
@@ -161,6 +168,7 @@
         this.hasComponent = false;
         this.label = `<${el.tagName.toLowerCase()}>`;
         this.filePath = null;
+        this.wraps = null;
         this.copyText = this.label;
       },
 
@@ -244,7 +252,8 @@
       }
     }
 
-    &__path {
+    &__path,
+    &__wraps {
       font-weight: normal;
       opacity: 0.85;
     }

--- a/src/components/c-vas-x-ray-overlay.vue
+++ b/src/components/c-vas-x-ray-overlay.vue
@@ -20,10 +20,9 @@
             v-if="current.wraps"
             :class="b('wraps')"
           >wraps {{ current.wraps }}</span>
-          <span
-            v-if="depthHint"
-            :class="b('depth')"
-          >{{ depthHint }} · {{ navigateHint }}</span>
+          <span :class="b('depth')">
+            <template v-if="depthHint">{{ depthHint }} · {{ navigateHint }} · </template>Enter to copy
+          </span>
         </template>
       </div>
     </template>
@@ -62,7 +61,8 @@
    * Full-viewport hover inspector for x-ray mode: highlights the Vue component under the cursor,
    * lets you step through its component-only ancestor chain (Alt/Option+↑ parent / Alt/Option+↓
    * child) — skipping every plain DOM node in between — and copies the selected one's file path
-   * (or name, if no file is resolvable) on click.
+   * (or name, if no file is resolvable) on click or on Enter, so the whole flow can be driven from
+   * the keyboard once the mouse has picked a starting element.
    */
   export default defineComponent({
     name: 'c-vas-x-ray-overlay',
@@ -207,6 +207,15 @@
       },
 
       handleKeyDown(event: KeyboardEvent): void {
+        // Enter copies the currently selected entry without needing a mouse click — lets the whole
+        // hover → navigate ancestors → copy flow stay on the keyboard once hovering has started.
+        if (event.key === 'Enter' && this.current) {
+          event.preventDefault();
+          this.performCopy();
+
+          return;
+        }
+
         if (!event.altKey || this.breadcrumb.length < 2) {
           return;
         }
@@ -229,7 +238,10 @@
 
         event.preventDefault();
         event.stopPropagation();
+        this.performCopy();
+      },
 
+      performCopy(): void {
         if (!this.copyText) {
           return;
         }

--- a/src/components/c-vas-x-ray-overlay.vue
+++ b/src/components/c-vas-x-ray-overlay.vue
@@ -23,7 +23,7 @@
           <span
             v-if="depthHint"
             :class="b('depth')"
-          >{{ depthHint }} · Alt+↑/↓</span>
+          >{{ depthHint }} · {{ navigateHint }}</span>
         </template>
       </div>
     </template>
@@ -33,6 +33,7 @@
 <script lang="ts">
   import { defineComponent } from 'vue';
   import { formatCopyText, getComponentBreadcrumb } from '../utils/vue-component-inspector';
+  import { isMac } from '../utils/platform';
 
   // type Setup = {};
 
@@ -54,13 +55,14 @@
   };
 
   const SIDEBAR_SELECTOR = '.c-vas-sidebar';
-  const LABEL_OFFSET_PX = 22;
+  const LABEL_INSET_PX = 6;
   const COPIED_FEEDBACK_MS = 1200;
 
   /**
    * Full-viewport hover inspector for x-ray mode: highlights the Vue component under the cursor,
-   * lets you step through its component-only ancestor chain (Alt+↑ parent / Alt+↓ child) — skipping
-   * every plain DOM node in between — and copies the selected one's name + file path on click.
+   * lets you step through its component-only ancestor chain (Alt/Option+↑ parent / Alt/Option+↓
+   * child) — skipping every plain DOM node in between — and copies the selected one's file path
+   * (or name, if no file is resolvable) on click.
    */
   export default defineComponent({
     name: 'c-vas-x-ray-overlay',
@@ -101,16 +103,43 @@
         return this.breadcrumb.length > 1 ? `${this.selectedIndex + 1}/${this.breadcrumb.length}` : null;
       },
 
+      navigateHint(): string {
+        return isMac() ? '⌥+↑/↓' : 'Alt+↑/↓';
+      },
+
       copyText(): string {
         return this.current ? formatCopyText(this.current) : '';
       },
 
       boxStyle(): Record<string, string> {
-        return this.rectStyle(0);
+        if (!this.current) {
+          return {};
+        }
+
+        const rect = this.current.el.getBoundingClientRect();
+
+        return {
+          top: `${rect.top}px`,
+          left: `${rect.left}px`,
+          width: `${rect.width}px`,
+          height: `${rect.height}px`,
+        };
       },
 
+      // Anchored to the box's own inner top-left corner rather than floating above it — a label
+      // placed above the box goes off-screen (invisible) whenever the highlighted element sits at
+      // or near the very top of the viewport.
       labelStyle(): Record<string, string> {
-        return this.rectStyle(-LABEL_OFFSET_PX);
+        if (!this.current) {
+          return {};
+        }
+
+        const rect = this.current.el.getBoundingClientRect();
+
+        return {
+          top: `${rect.top + LABEL_INSET_PX}px`,
+          left: `${rect.left + LABEL_INSET_PX}px`,
+        };
       },
     },
     // watch: {},
@@ -143,21 +172,6 @@
     // unmounted() {},
 
     methods: {
-      rectStyle(topOffset: number): Record<string, string> {
-        if (!this.current) {
-          return {};
-        }
-
-        const rect = this.current.el.getBoundingClientRect();
-
-        return {
-          top: `${rect.top + topOffset}px`,
-          left: `${rect.left}px`,
-          width: topOffset === 0 ? `${rect.width}px` : 'auto',
-          height: topOffset === 0 ? `${rect.height}px` : 'auto',
-        };
-      },
-
       isSidebarChrome(el: Element | null): boolean {
         return Boolean(el?.closest(SIDEBAR_SELECTOR));
       },

--- a/src/components/c-vas-x-ray-overlay.vue
+++ b/src/components/c-vas-x-ray-overlay.vue
@@ -1,0 +1,252 @@
+<template>
+  <div :class="b()">
+    <template v-if="target">
+      <div
+        :class="b('box', { unresolved: !hasComponent })"
+        :style="boxStyle"
+      ></div>
+      <div
+        :class="b('label', { unresolved: !hasComponent, copied })"
+        :style="labelStyle"
+      >
+        <template v-if="copied">Copied!</template>
+        <template v-else>
+          <span :class="b('name')">{{ label }}</span>
+          <span
+            v-if="filePath"
+            :class="b('path')"
+          >{{ filePath }}</span>
+        </template>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script lang="ts">
+  import { defineComponent } from 'vue';
+  import { formatCopyText, resolveComponentAtElement } from '../utils/vue-component-inspector';
+
+  // type Setup = {};
+
+  type Data = {
+    target: Element | null;
+    hasComponent: boolean;
+    label: string;
+    filePath: string | null;
+    copyText: string;
+    copied: boolean;
+    copiedTimeout: ReturnType<typeof setTimeout> | null;
+    frame: number | null;
+  };
+
+  const SIDEBAR_SELECTOR = '.c-vas-sidebar';
+  const LABEL_OFFSET_PX = 22;
+  const COPIED_FEEDBACK_MS = 1200;
+
+  /**
+   * Full-viewport hover inspector for x-ray mode: highlights the Vue component under the
+   * cursor and copies its name + file path to the clipboard on click.
+   */
+  export default defineComponent({
+    name: 'c-vas-x-ray-overlay',
+
+    // components: {},
+
+    // props: {},
+    // emits: {},
+
+    // setup(): Setup {
+    //   return {};
+    // },
+    data(): Data {
+      return {
+        target: null,
+        hasComponent: false,
+        label: '',
+        filePath: null,
+        copyText: '',
+        copied: false,
+        copiedTimeout: null,
+        frame: null,
+      };
+    },
+
+    computed: {
+      boxStyle(): Record<string, string> {
+        return this.rectStyle(0);
+      },
+
+      labelStyle(): Record<string, string> {
+        return this.rectStyle(-LABEL_OFFSET_PX);
+      },
+    },
+    // watch: {},
+
+    // beforeCreate() {},
+    // created() {},
+    // beforeMount() {},
+    mounted() {
+      document.addEventListener('mousemove', this.handleMouseMove);
+      document.addEventListener('click', this.handleClick, { capture: true });
+    },
+    // beforeUpdate() {},
+    // updated() {},
+    // activated() {},
+    // deactivated() {},
+    beforeUnmount() {
+      document.removeEventListener('mousemove', this.handleMouseMove);
+      document.removeEventListener('click', this.handleClick, { capture: true });
+
+      if (this.frame !== null) {
+        cancelAnimationFrame(this.frame);
+      }
+
+      if (this.copiedTimeout) {
+        clearTimeout(this.copiedTimeout);
+      }
+    },
+    // unmounted() {},
+
+    methods: {
+      rectStyle(topOffset: number): Record<string, string> {
+        if (!this.target) {
+          return {};
+        }
+
+        const rect = this.target.getBoundingClientRect();
+
+        return {
+          top: `${rect.top + topOffset}px`,
+          left: `${rect.left}px`,
+          width: topOffset === 0 ? `${rect.width}px` : 'auto',
+          height: topOffset === 0 ? `${rect.height}px` : 'auto',
+        };
+      },
+
+      isSidebarChrome(el: Element | null): boolean {
+        return Boolean(el?.closest(SIDEBAR_SELECTOR));
+      },
+
+      handleMouseMove(event: MouseEvent): void {
+        if (this.frame !== null) {
+          return;
+        }
+
+        this.frame = requestAnimationFrame(() => {
+          this.frame = null;
+          this.updateTarget(event.target as Element | null);
+        });
+      },
+
+      updateTarget(el: Element | null): void {
+        if (!el || this.isSidebarChrome(el)) {
+          this.target = null;
+
+          return;
+        }
+
+        const resolved = resolveComponentAtElement(el);
+
+        if (resolved) {
+          this.target = resolved.el;
+          this.hasComponent = true;
+          this.label = resolved.name;
+          this.filePath = resolved.file;
+          this.copyText = formatCopyText(resolved);
+
+          return;
+        }
+
+        this.target = el;
+        this.hasComponent = false;
+        this.label = `<${el.tagName.toLowerCase()}>`;
+        this.filePath = null;
+        this.copyText = this.label;
+      },
+
+      handleClick(event: MouseEvent): void {
+        const el = event.target as Element | null;
+
+        if (this.isSidebarChrome(el)) {
+          return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (!this.copyText) {
+          return;
+        }
+
+        navigator.clipboard
+          ?.writeText(this.copyText)
+          .then(() => {
+            this.copied = true;
+
+            if (this.copiedTimeout) {
+              clearTimeout(this.copiedTimeout);
+            }
+
+            this.copiedTimeout = setTimeout(() => {
+              this.copied = false;
+            }, COPIED_FEEDBACK_MS);
+          })
+          .catch(() => {
+            // Clipboard write can fail (permissions, insecure context) — the inspector keeps working regardless.
+          });
+      },
+    },
+    // render() {},
+  });
+</script>
+
+<style lang="scss">
+  @use '../setup/scss/variables';
+
+  .c-vas-x-ray-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 999;
+    pointer-events: none;
+
+    &__box {
+      position: absolute;
+      border: 2px solid variables.$vas-color-valantic-primary;
+      border-radius: 2px;
+      background-color: rgba(255, 93, 76, 8%);
+
+      &--unresolved {
+        border-color: variables.$vas-color-grayscale--400;
+        background-color: transparent;
+      }
+    }
+
+    &__label {
+      position: absolute;
+      display: flex;
+      align-items: baseline;
+      gap: variables.$vas-spacing--6;
+      padding: variables.$vas-spacing--4 variables.$vas-spacing--8;
+      border-radius: variables.$vas-theme-border-radius;
+      background-color: variables.$vas-color-valantic-primary;
+      color: variables.$vas-color-white;
+      font-family: variables.$vas-font-family--sidebar;
+      font-size: var(--vas-font-size-small);
+      font-weight: variables.$vas-font-weight--semi-bold;
+      white-space: nowrap;
+
+      &--unresolved {
+        background-color: variables.$vas-color-grayscale--400;
+      }
+
+      &--copied {
+        background-color: variables.$vas-color-green-primary;
+      }
+    }
+
+    &__path {
+      font-weight: normal;
+      opacity: 0.85;
+    }
+  }
+</style>

--- a/src/components/c-vas-x-ray-toast.vue
+++ b/src/components/c-vas-x-ray-toast.vue
@@ -1,0 +1,120 @@
+<template>
+  <transition :name="b('fade')">
+    <div
+      v-if="visible"
+      :class="b()"
+    >
+      {{ message }}
+    </div>
+  </transition>
+</template>
+
+<script lang="ts">
+  import { defineComponent } from 'vue';
+  import { type VasSettingsStore, useVasSettingsStore } from '../stores/settings';
+
+  type Setup = {
+    vasSettingsStore: VasSettingsStore;
+  };
+
+  type Data = {
+    visible: boolean;
+    message: string;
+    hideTimeout: ReturnType<typeof setTimeout> | null;
+  };
+
+  const VISIBLE_DURATION_MS = 2500;
+
+  /**
+   * Brief top-right toast confirming that x-ray mode was toggled on or off, however it was
+   * toggled (hotkey or the Features panel switch) — both just flip the same store value.
+   */
+  export default defineComponent({
+    name: 'c-vas-x-ray-toast',
+
+    // components: {},
+
+    // props: {},
+    // emits: {},
+
+    setup(): Setup {
+      return {
+        vasSettingsStore: useVasSettingsStore(),
+      };
+    },
+    data(): Data {
+      return {
+        visible: false,
+        message: '',
+        hideTimeout: null,
+      };
+    },
+
+    // computed: {},
+    watch: {
+      'vasSettingsStore.state.isXRayModeEnabled': function (enabled: boolean) {
+        this.message = enabled ? 'X-ray mode enabled' : 'X-ray mode disabled';
+        this.visible = true;
+
+        if (this.hideTimeout) {
+          clearTimeout(this.hideTimeout);
+        }
+
+        this.hideTimeout = setTimeout(() => {
+          this.visible = false;
+        }, VISIBLE_DURATION_MS);
+      },
+    },
+
+    // beforeCreate() {},
+    // created() {},
+    // beforeMount() {},
+    // mounted() {},
+    // beforeUpdate() {},
+    // updated() {},
+    // activated() {},
+    // deactivated() {},
+    beforeUnmount() {
+      if (this.hideTimeout) {
+        clearTimeout(this.hideTimeout);
+      }
+    },
+    // unmounted() {},
+
+    // methods: {},
+    // render() {},
+  });
+</script>
+
+<style lang="scss">
+  @use '../setup/scss/variables';
+
+  .c-vas-x-ray-toast {
+    position: fixed;
+    top: variables.$vas-spacing--20;
+    right: variables.$vas-spacing--20;
+    z-index: 1000;
+    padding: variables.$vas-spacing--8 variables.$vas-spacing--16;
+    border-radius: variables.$vas-theme-border-radius;
+    background-color: variables.$vas-color-valantic-primary;
+    color: variables.$vas-color-white;
+    font-family: variables.$vas-font-family--sidebar;
+    font-size: var(--vas-font-size-base);
+    font-weight: variables.$vas-font-weight--semi-bold;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 20%);
+    pointer-events: none;
+
+    &__fade-enter-active,
+    &__fade-leave-active {
+      transition:
+        opacity variables.$vas-transition--default,
+        transform variables.$vas-transition--default;
+    }
+
+    &__fade-enter-from,
+    &__fade-leave-to {
+      transform: translateY(-8px);
+      opacity: 0;
+    }
+  }
+</style>

--- a/src/config/hotkeys.ts
+++ b/src/config/hotkeys.ts
@@ -79,4 +79,11 @@ export const HOTKEYS: HotkeyEntry[] = [
       display: [['⌥', '+', '↑'], ['⌥', '+', '↓']],
     },
   },
+  {
+    id: 'x-ray-mode-copy',
+    tip: 'Enter — copy selected component',
+    description:
+      'While x-ray mode is hovering an element, copy the currently selected component (same as clicking it) without needing the mouse.',
+    display: [['Enter']],
+  },
 ];

--- a/src/config/hotkeys.ts
+++ b/src/config/hotkeys.ts
@@ -60,19 +60,23 @@ export const HOTKEYS: HotkeyEntry[] = [
   },
   {
     id: 'toggle-x-ray-mode',
-    tip: 'Ctrl + Shift + X — toggle x-ray mode',
+    tip: 'Ctrl + Alt + X — toggle x-ray mode',
     description: 'Toggle x-ray mode. Hover any element to see its Vue component name, click to copy it.',
-    display: [['Ctrl', '+', 'Shift', '+', 'X']],
+    display: [['Ctrl', '+', 'Alt', '+', 'X']],
     mac: {
-      tip: '⌘ + ⇧ + X — toggle x-ray mode',
-      display: [['⌘', '+', 'Shift', '+', 'X']],
+      tip: '⌘ + ⌥ + X — toggle x-ray mode',
+      display: [['⌘', '+', '⌥', '+', 'X']],
     },
   },
   {
     id: 'x-ray-mode-navigate-ancestors',
     tip: 'Alt + ↑ / ↓ — navigate component ancestors',
     description:
-      'While x-ray mode is hovering an element, step through its component-only ancestor chain (Alt + ↑ for the parent component, Alt + ↓ back down).',
+      'While x-ray mode is hovering an element, step through its component-only ancestor chain (Alt/Option + ↑ for the parent component, Alt/Option + ↓ back down).',
     display: [['Alt', '+', '↑'], ['Alt', '+', '↓']],
+    mac: {
+      tip: '⌥ + ↑ / ↓ — navigate component ancestors',
+      display: [['⌥', '+', '↑'], ['⌥', '+', '↓']],
+    },
   },
 ];

--- a/src/config/hotkeys.ts
+++ b/src/config/hotkeys.ts
@@ -68,4 +68,11 @@ export const HOTKEYS: HotkeyEntry[] = [
       display: [['⌘', '+', 'Shift', '+', 'X']],
     },
   },
+  {
+    id: 'x-ray-mode-navigate-ancestors',
+    tip: 'Alt + ↑ / ↓ — navigate component ancestors',
+    description:
+      'While x-ray mode is hovering an element, step through its component-only ancestor chain (Alt + ↑ for the parent component, Alt + ↓ back down).',
+    display: [['Alt', '+', '↑'], ['Alt', '+', '↓']],
+  },
 ];

--- a/src/config/hotkeys.ts
+++ b/src/config/hotkeys.ts
@@ -58,4 +58,14 @@ export const HOTKEYS: HotkeyEntry[] = [
     description: 'Closes the sidebar, closes modal.',
     display: [['Esc']],
   },
+  {
+    id: 'toggle-x-ray-mode',
+    tip: 'Ctrl + Shift + X — toggle x-ray mode',
+    description: 'Toggle x-ray mode. Hover any element to see its Vue component name, click to copy it.',
+    display: [['Ctrl', '+', 'Shift', '+', 'X']],
+    mac: {
+      tip: '⌘ + ⇧ + X — toggle x-ray mode',
+      display: [['⌘', '+', 'Shift', '+', 'X']],
+    },
+  },
 ];

--- a/src/features/c-vas-x-ray-mode.vue
+++ b/src/features/c-vas-x-ray-mode.vue
@@ -1,16 +1,40 @@
 <template>
-  <e-vas-toggle v-model="enabled"> X-ray mode </e-vas-toggle>
+  <div :class="b()">
+    <e-vas-toggle v-model="enabled"> X-ray mode </e-vas-toggle>
+
+    <p
+      v-if="enabled && !markerActive"
+      :class="b('warning')"
+    >
+      For accurate results across third-party components, install the x-ray inspector plugin — see the
+      <a
+        :href="setupGuideUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        >setup guide</a
+      >.
+    </p>
+  </div>
 </template>
 
 <script lang="ts">
   import { defineComponent } from 'vue';
   import eVasToggle from '../elements/e-vas-toggle.vue';
   import { type VasSettingsStore, useVasSettingsStore } from '../stores/settings';
+  import { hasComponentMarker } from '../utils/vue-component-inspector';
 
   type Setup = {
     vasSettingsStore: VasSettingsStore;
   };
-  // type Data = {};
+
+  type Data = {
+    // Whether the vasXRayInspector plugin marked this component's own root element on mount —
+    // the simplest reliable proof that it's actually registered on this app. Optimistic default
+    // to avoid flashing a false warning before mounted() has had a chance to check.
+    markerActive: boolean;
+  };
+
+  const SETUP_GUIDE_URL = 'https://github.com/valantic/vue-styleguide/blob/main/docs/x-ray-mode.md';
 
   /**
    * Adds a toggle to en-/disable x-ray mode: hover any element to see its Vue component name
@@ -31,9 +55,11 @@
         vasSettingsStore: useVasSettingsStore(),
       };
     },
-    // data(): Data {
-    //   return {};
-    // },
+    data(): Data {
+      return {
+        markerActive: true,
+      };
+    },
 
     computed: {
       enabled: {
@@ -44,13 +70,19 @@
           this.vasSettingsStore.setXRayModeEnabled(value);
         },
       },
+
+      setupGuideUrl(): string {
+        return SETUP_GUIDE_URL;
+      },
     },
     // watch: {},
 
     // beforeCreate() {},
     // created() {},
     // beforeMount() {},
-    // mounted() {},
+    mounted() {
+      this.markerActive = hasComponentMarker(this.$el);
+    },
     // beforeUpdate() {},
     // updated() {},
     // activated() {},
@@ -62,3 +94,24 @@
     // render() {},
   });
 </script>
+
+<style lang="scss">
+  @use '../setup/scss/variables';
+
+  .c-vas-x-ray-mode {
+    display: flex;
+    flex-direction: column;
+    gap: variables.$vas-spacing--8;
+
+    &__warning {
+      margin: 0;
+      color: variables.$vas-color-status--error;
+      font-size: var(--vas-font-size-small);
+
+      a {
+        color: inherit;
+        text-decoration: underline;
+      }
+    }
+  }
+</style>

--- a/src/features/c-vas-x-ray-mode.vue
+++ b/src/features/c-vas-x-ray-mode.vue
@@ -1,0 +1,64 @@
+<template>
+  <e-vas-toggle v-model="enabled"> X-ray mode </e-vas-toggle>
+</template>
+
+<script lang="ts">
+  import { defineComponent } from 'vue';
+  import eVasToggle from '../elements/e-vas-toggle.vue';
+  import { type VasSettingsStore, useVasSettingsStore } from '../stores/settings';
+
+  type Setup = {
+    vasSettingsStore: VasSettingsStore;
+  };
+  // type Data = {};
+
+  /**
+   * Adds a toggle to en-/disable x-ray mode: hover any element to see its Vue component name
+   * and file path, click to copy them to the clipboard.
+   */
+  export default defineComponent({
+    name: 'c-vas-x-ray-mode',
+
+    components: {
+      eVasToggle,
+    },
+
+    // props: {},
+    // emits: {},
+
+    setup(): Setup {
+      return {
+        vasSettingsStore: useVasSettingsStore(),
+      };
+    },
+    // data(): Data {
+    //   return {};
+    // },
+
+    computed: {
+      enabled: {
+        get(): boolean {
+          return this.vasSettingsStore.state.isXRayModeEnabled;
+        },
+        set(value: boolean) {
+          this.vasSettingsStore.setXRayModeEnabled(value);
+        },
+      },
+    },
+    // watch: {},
+
+    // beforeCreate() {},
+    // created() {},
+    // beforeMount() {},
+    // mounted() {},
+    // beforeUpdate() {},
+    // updated() {},
+    // activated() {},
+    // deactivated() {},
+    // beforeUnmount() {},
+    // unmounted() {},
+
+    // methods: {},
+    // render() {},
+  });
+</script>

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,5 @@ export * from './features/index';
 
 export * from './stores/settings';
 export * from './stores/local-store';
+
+export { default as vasXRayInspector } from './plugins/x-ray-inspector';

--- a/src/plugins/x-ray-inspector.ts
+++ b/src/plugins/x-ray-inspector.ts
@@ -5,11 +5,12 @@ import { markComponentInstance } from '../utils/vue-component-inspector';
  * Marks every component's root DOM element with its name and source file, via a global mixin,
  * so x-ray mode can resolve accurate component boundaries — including third-party components
  * (e.g. from Vuetify) — instead of relying solely on Vue's internal, single-slot
- * `__vueParentComponent` reference. Register once, before `app.mount()`:
- *
- *   import { vasXRayInspector } from '@valantic/vue-styleguide';
+ * `__vueParentComponent` reference. Register once, before `app.mount()` — import it dynamically
+ * inside a dev-only check so it's never even requested in a production build:
  *
  *   if (import.meta.env.DEV) {
+ *     const { vasXRayInspector } = await import('@valantic/vue-styleguide');
+ *
  *     app.use(vasXRayInspector);
  *   }
  *

--- a/src/plugins/x-ray-inspector.ts
+++ b/src/plugins/x-ray-inspector.ts
@@ -1,0 +1,32 @@
+import type { App, ComponentPublicInstance, Plugin } from 'vue';
+import { markComponentInstance } from '../utils/vue-component-inspector';
+
+/**
+ * Marks every component's root DOM element with its name and source file, via a global mixin,
+ * so x-ray mode can resolve accurate component boundaries — including third-party components
+ * (e.g. from Vuetify) — instead of relying solely on Vue's internal, single-slot
+ * `__vueParentComponent` reference. Register once, before `app.mount()`:
+ *
+ *   import { vasXRayInspector } from '@valantic/vue-styleguide';
+ *
+ *   if (import.meta.env.DEV) {
+ *     app.use(vasXRayInspector);
+ *   }
+ *
+ * See docs/x-ray-mode.md for the full setup guide.
+ */
+export default {
+  install(app: App): void {
+    app.mixin({
+      mounted(this: ComponentPublicInstance): void {
+        const options = this.$options as { name?: string; __name?: string; __file?: string };
+        // eslint-disable-next-line no-underscore-dangle
+        const name = options.name ?? options.__name ?? null;
+        // eslint-disable-next-line no-underscore-dangle
+        const file = options.__file ?? null;
+
+        markComponentInstance(this.$el, name, file);
+      },
+    });
+  },
+} satisfies Plugin;

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -21,6 +21,7 @@ export const FONT_SIZE_DEFAULT = 13;
 const state = reactive({
   theme: vasLocalStore.get<Theme>('theme', 'system'),
   fontSize: vasLocalStore.get<number>('fontSize', FONT_SIZE_DEFAULT),
+  isXRayModeEnabled: vasLocalStore.get<boolean>('x-ray-mode', false),
 });
 
 export const useVasSettingsStore = () => {
@@ -37,6 +38,11 @@ export const useVasSettingsStore = () => {
 
       state.fontSize = clamped;
       vasLocalStore.set('fontSize', clamped);
+    },
+
+    setXRayModeEnabled(enabled: boolean): void {
+      state.isXRayModeEnabled = enabled;
+      vasLocalStore.set('x-ray-mode', enabled);
     },
   };
 };

--- a/src/utils/vue-component-inspector.ts
+++ b/src/utils/vue-component-inspector.ts
@@ -83,22 +83,18 @@ export function getComponentFilePath(instance: VueInternalInstance): string | nu
   return markerIndex === -1 ? file : file.slice(markerIndex + 1);
 }
 
-// Prefer the outermost layer in the stack that has a resolvable source file. Third-party
-// components (e.g. from Vuetify) are pre-compiled and never carry one, so this naturally
-// skips past them to surface the consumer's own wrapping component instead.
+// Prefer the innermost layer in the stack that has a resolvable source file — i.e. skip past
+// third-party components (e.g. from Vuetify), which are pre-compiled and never carry one, but
+// stop at the first layer that does rather than climbing all the way out to some outer,
+// unrelated container that merely happens to also render without a wrapping element.
 function pickPreferredInstance(stack: ComponentStack): VueInternalInstance {
-  const outerToInner = [...stack].reverse();
-
-  for (const candidate of outerToInner) {
+  for (const candidate of stack) {
     if (getComponentFilePath(candidate)) {
       return candidate;
     }
   }
 
-  // Array.prototype.at() isn't in this project's configured TS lib target — index access is
-  // equivalent here since `stack` is always non-empty.
-  // eslint-disable-next-line unicorn/prefer-at
-  return stack[stack.length - 1] ?? stack[0];
+  return stack[0];
 }
 
 export function resolveComponentAtElement(el: Element | null): ResolvedComponent | null {
@@ -131,4 +127,89 @@ export function formatCopyText(resolved: ResolvedComponent): string {
   const base = resolved.file ? `${resolved.name} (${resolved.file})` : resolved.name;
 
   return resolved.wraps ? `${base} — wraps ${resolved.wraps}` : base;
+}
+
+// --- Marker-based resolution -------------------------------------------------------------
+//
+// __vueParentComponent only ever reflects the single deepest component sharing a DOM root.
+// It can't see past a nearby generic container (e.g. a Vuetify VCol) to a meaningful ancestor
+// elsewhere in the DOM tree — that's a different node entirely, not a collapsed-root situation.
+//
+// The `vasXRayInspector` plugin (see ../plugins/x-ray-inspector) fixes this by having every
+// component mark its own root element via markComponentInstance() when mounted, using a global
+// mixin — which also applies to third-party components (Vuetify, etc.), since they're mounted by
+// the same app. That gives an accurate, complete marker at every real component boundary, letting
+// the breadcrumb walk below build a clean, component-only ancestor chain. __vueParentComponent
+// remains as a same-element fallback for when the plugin isn't installed.
+
+export type MarkerEntry = { name: string; file: string | null };
+
+type MarkedElement = Element & { vasComponents?: MarkerEntry[] };
+
+export function markComponentInstance(el: unknown, name: string | null, file: string | null): void {
+  if (!(el instanceof Element) || !name) {
+    return;
+  }
+
+  const marked = el as MarkedElement;
+
+  marked.vasComponents = [...(marked.vasComponents ?? []), { name, file }];
+}
+
+// Used to detect whether the plugin is actually registered on the running app — check a DOM
+// element known to belong to a component that definitely mounted (e.g. the feature toggle's own
+// $el): if the plugin ran, that exact element carries at least one marker.
+export function hasComponentMarker(el: unknown): boolean {
+  return el instanceof Element && Boolean((el as MarkedElement).vasComponents?.length);
+}
+
+function pickPreferredMarkerEntry(entries: [MarkerEntry, ...MarkerEntry[]]): MarkerEntry {
+  for (const entry of entries) {
+    if (entry.file) {
+      return entry;
+    }
+  }
+
+  return entries[0];
+}
+
+function resolveMarkedElement(el: Element, entries: [MarkerEntry, ...MarkerEntry[]]): ResolvedComponent {
+  const preferred = pickPreferredMarkerEntry(entries);
+  const innermost = entries[0];
+  const wraps = preferred === innermost ? null : innermost.name;
+
+  return {
+    name: preferred.name,
+    file: preferred.file,
+    wraps: wraps === preferred.name ? null : wraps,
+    el,
+  };
+}
+
+// Walks every ancestor carrying component markers, nearest first — a clean, component-only
+// breadcrumb that skips every plain DOM node in between (divs, spans, layout wrappers with no
+// matching Vue component of their own). Falls back to a single best-effort entry via
+// resolveComponentAtElement() when no marker is found anywhere in the chain, i.e. the
+// vasXRayInspector plugin isn't installed on this app.
+export function getComponentBreadcrumb(el: Element | null): ResolvedComponent[] {
+  const breadcrumb: ResolvedComponent[] = [];
+  let current = el;
+
+  while (current) {
+    const entries = (current as MarkedElement).vasComponents;
+
+    if (entries && entries.length > 0) {
+      breadcrumb.push(resolveMarkedElement(current, entries as [MarkerEntry, ...MarkerEntry[]]));
+    }
+
+    current = current.parentElement;
+  }
+
+  if (breadcrumb.length > 0) {
+    return breadcrumb;
+  }
+
+  const fallback = resolveComponentAtElement(el);
+
+  return fallback ? [fallback] : [];
 }

--- a/src/utils/vue-component-inspector.ts
+++ b/src/utils/vue-component-inspector.ts
@@ -68,19 +68,23 @@ export function getComponentDisplayName(instance: VueInternalInstance): string |
 }
 
 // `__file` is a dev-only absolute filesystem path. Trimming to the last `/src/` segment is a
-// best-effort heuristic for a project-relative path — it won't be accurate for projects that
-// don't root their source in a `src/` folder.
-export function getComponentFilePath(instance: VueInternalInstance): string | null {
-  // eslint-disable-next-line no-underscore-dangle
-  const file = instance.type.__file;
-
+// best-effort heuristic for a project-relative path. When no such marker is found, this returns
+// null rather than the raw absolute path — that path contains the local username/filesystem layout,
+// which must never end up in the clipboard text. Callers fall back to the component name instead;
+// see formatCopyText().
+export function toProjectRelativePath(file: string | null | undefined): string | null {
   if (!file) {
     return null;
   }
 
   const markerIndex = file.lastIndexOf(SRC_MARKER);
 
-  return markerIndex === -1 ? file : file.slice(markerIndex + 1);
+  return markerIndex === -1 ? null : file.slice(markerIndex + 1);
+}
+
+export function getComponentFilePath(instance: VueInternalInstance): string | null {
+  // eslint-disable-next-line no-underscore-dangle
+  return toProjectRelativePath(instance.type.__file);
 }
 
 // Prefer the innermost layer in the stack that has a resolvable source file — i.e. skip past
@@ -123,10 +127,12 @@ export function resolveComponentAtElement(el: Element | null): ResolvedComponent
   };
 }
 
+// The clipboard payload is deliberately just one or the other, not a combined "Name (file)"
+// string: the file path (project-relative, not the full absolute user path) is the more directly
+// actionable reference for an AI coding prompt, and the name is only a fallback for when no file
+// is resolvable at all (e.g. a third-party component, or a plain DOM element with no component).
 export function formatCopyText(resolved: ResolvedComponent): string {
-  const base = resolved.file ? `${resolved.name} (${resolved.file})` : resolved.name;
-
-  return resolved.wraps ? `${base} — wraps ${resolved.wraps}` : base;
+  return resolved.file ?? resolved.name;
 }
 
 // --- Marker-based resolution -------------------------------------------------------------
@@ -146,6 +152,9 @@ export type MarkerEntry = { name: string; file: string | null };
 
 type MarkedElement = Element & { vasComponents?: MarkerEntry[] };
 
+// `file` is the raw, dev-only __file value straight off the component's options — trimmed to a
+// project-relative path here (see toProjectRelativePath()) so every caller gets the same
+// Leak-free result regardless of where the mark originates.
 export function markComponentInstance(el: unknown, name: string | null, file: string | null): void {
   if (!(el instanceof Element) || !name) {
     return;
@@ -153,7 +162,7 @@ export function markComponentInstance(el: unknown, name: string | null, file: st
 
   const marked = el as MarkedElement;
 
-  marked.vasComponents = [...(marked.vasComponents ?? []), { name, file }];
+  marked.vasComponents = [...(marked.vasComponents ?? []), { name, file: toProjectRelativePath(file) }];
 }
 
 // Used to detect whether the plugin is actually registered on the running app — check a DOM

--- a/src/utils/vue-component-inspector.ts
+++ b/src/utils/vue-component-inspector.ts
@@ -8,6 +8,8 @@ type VueInternalComponentType = {
 
 type VueInternalInstance = {
   type: VueInternalComponentType;
+  parent: VueInternalInstance | null;
+  vnode: { el: unknown };
 };
 
 type VueInternalElement = Element & {
@@ -17,6 +19,9 @@ type VueInternalElement = Element & {
 export type ResolvedComponent = {
   name: string;
   file: string | null;
+  // Set when the reported component is a wrapper we substituted in for a same-root child
+  // (e.g. a third-party component with no source file) — see resolveComponentAtElement.
+  wraps: string | null;
   el: Element;
 };
 
@@ -37,6 +42,24 @@ export function findComponentInstance(el: Element | null): { instance: VueIntern
   }
 
   return null;
+}
+
+type ComponentStack = [VueInternalInstance, ...VueInternalInstance[]];
+
+// When a component's template root is itself another component (no wrapping element), both
+// instances share the exact same DOM node — Vue only keeps the innermost one on `__vueParentComponent`.
+// Walking `instance.parent` while its root element (`vnode.el`) stays the same DOM node recovers
+// the full stack of collapsed layers at that spot, ordered innermost (leaf) to outermost.
+export function collectStackedInstances(instance: VueInternalInstance, el: Element): ComponentStack {
+  const stack: ComponentStack = [instance];
+  let current = instance;
+
+  while (current.parent && current.parent.vnode?.el === el) {
+    current = current.parent;
+    stack.push(current);
+  }
+
+  return stack;
 }
 
 export function getComponentDisplayName(instance: VueInternalInstance): string | null {
@@ -60,6 +83,24 @@ export function getComponentFilePath(instance: VueInternalInstance): string | nu
   return markerIndex === -1 ? file : file.slice(markerIndex + 1);
 }
 
+// Prefer the outermost layer in the stack that has a resolvable source file. Third-party
+// components (e.g. from Vuetify) are pre-compiled and never carry one, so this naturally
+// skips past them to surface the consumer's own wrapping component instead.
+function pickPreferredInstance(stack: ComponentStack): VueInternalInstance {
+  const outerToInner = [...stack].reverse();
+
+  for (const candidate of outerToInner) {
+    if (getComponentFilePath(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Array.prototype.at() isn't in this project's configured TS lib target — index access is
+  // equivalent here since `stack` is always non-empty.
+  // eslint-disable-next-line unicorn/prefer-at
+  return stack[stack.length - 1] ?? stack[0];
+}
+
 export function resolveComponentAtElement(el: Element | null): ResolvedComponent | null {
   const found = findComponentInstance(el);
 
@@ -67,19 +108,27 @@ export function resolveComponentAtElement(el: Element | null): ResolvedComponent
     return null;
   }
 
-  const name = getComponentDisplayName(found.instance);
+  const stack = collectStackedInstances(found.instance, found.el);
+  const preferred = pickPreferredInstance(stack);
+  const name = getComponentDisplayName(preferred);
 
   if (!name) {
     return null;
   }
 
+  const innermost = stack[0];
+  const wraps = preferred === innermost ? null : getComponentDisplayName(innermost);
+
   return {
     name,
-    file: getComponentFilePath(found.instance),
+    file: getComponentFilePath(preferred),
+    wraps: wraps === name ? null : wraps,
     el: found.el,
   };
 }
 
 export function formatCopyText(resolved: ResolvedComponent): string {
-  return resolved.file ? `${resolved.name} (${resolved.file})` : resolved.name;
+  const base = resolved.file ? `${resolved.name} (${resolved.file})` : resolved.name;
+
+  return resolved.wraps ? `${base} — wraps ${resolved.wraps}` : base;
 }

--- a/src/utils/vue-component-inspector.ts
+++ b/src/utils/vue-component-inspector.ts
@@ -1,0 +1,85 @@
+// Vue attaches `__vueParentComponent` to DOM elements at runtime — the same undocumented internal
+// that Vue Devtools and vue-test-utils rely on to map a DOM node back to its component instance.
+type VueInternalComponentType = {
+  name?: string;
+  __name?: string;
+  __file?: string;
+};
+
+type VueInternalInstance = {
+  type: VueInternalComponentType;
+};
+
+type VueInternalElement = Element & {
+  __vueParentComponent?: VueInternalInstance;
+};
+
+export type ResolvedComponent = {
+  name: string;
+  file: string | null;
+  el: Element;
+};
+
+const SRC_MARKER = '/src/';
+
+export function findComponentInstance(el: Element | null): { instance: VueInternalInstance; el: Element } | null {
+  let current = el;
+
+  while (current) {
+    // eslint-disable-next-line no-underscore-dangle
+    const instance = (current as VueInternalElement).__vueParentComponent;
+
+    if (instance?.type) {
+      return { instance, el: current };
+    }
+
+    current = current.parentElement;
+  }
+
+  return null;
+}
+
+export function getComponentDisplayName(instance: VueInternalInstance): string | null {
+  // eslint-disable-next-line no-underscore-dangle
+  return instance.type.name ?? instance.type.__name ?? null;
+}
+
+// `__file` is a dev-only absolute filesystem path. Trimming to the last `/src/` segment is a
+// best-effort heuristic for a project-relative path — it won't be accurate for projects that
+// don't root their source in a `src/` folder.
+export function getComponentFilePath(instance: VueInternalInstance): string | null {
+  // eslint-disable-next-line no-underscore-dangle
+  const file = instance.type.__file;
+
+  if (!file) {
+    return null;
+  }
+
+  const markerIndex = file.lastIndexOf(SRC_MARKER);
+
+  return markerIndex === -1 ? file : file.slice(markerIndex + 1);
+}
+
+export function resolveComponentAtElement(el: Element | null): ResolvedComponent | null {
+  const found = findComponentInstance(el);
+
+  if (!found) {
+    return null;
+  }
+
+  const name = getComponentDisplayName(found.instance);
+
+  if (!name) {
+    return null;
+  }
+
+  return {
+    name,
+    file: getComponentFilePath(found.instance),
+    el: found.el,
+  };
+}
+
+export function formatCopyText(resolved: ResolvedComponent): string {
+  return resolved.file ? `${resolved.name} (${resolved.file})` : resolved.name;
+}

--- a/tests/unit/specs/components/c-vas-x-ray-toast.test.ts
+++ b/tests/unit/specs/components/c-vas-x-ray-toast.test.ts
@@ -1,0 +1,80 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import cVasXRayToast from '../../../../src/components/c-vas-x-ray-toast.vue';
+import vueBemCn from '../../../../src/plugins/vue-bem-cn';
+import { useVasSettingsStore } from '../../../../src/stores/settings';
+
+type ToastInstance = { visible: boolean; message: string };
+
+const mountComponent = () => mount(cVasXRayToast, { global: { plugins: [vueBemCn] } });
+const vm = (wrapper: ReturnType<typeof mountComponent>) => wrapper.vm as unknown as ToastInstance;
+
+describe('c-vas-x-ray-toast', () => {
+  const vasSettingsStore = useVasSettingsStore();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vasSettingsStore.setXRayModeEnabled(false);
+  });
+
+  afterEach(() => {
+    vasSettingsStore.setXRayModeEnabled(false);
+    vi.useRealTimers();
+  });
+
+  test('is not visible initially', () => {
+    expect(vm(mountComponent()).visible).toBe(false);
+  });
+
+  test('shows an "enabled" message when x-ray mode is turned on', async () => {
+    const wrapper = mountComponent();
+
+    vasSettingsStore.setXRayModeEnabled(true);
+    await wrapper.vm.$nextTick();
+
+    expect(vm(wrapper).visible).toBe(true);
+    expect(vm(wrapper).message).toBe('X-ray mode enabled');
+  });
+
+  test('shows a "disabled" message when x-ray mode is turned off', async () => {
+    vasSettingsStore.setXRayModeEnabled(true);
+
+    const wrapper = mountComponent();
+
+    vasSettingsStore.setXRayModeEnabled(false);
+    await wrapper.vm.$nextTick();
+
+    expect(vm(wrapper).visible).toBe(true);
+    expect(vm(wrapper).message).toBe('X-ray mode disabled');
+  });
+
+  test('hides itself again once the visible duration elapses', async () => {
+    const wrapper = mountComponent();
+
+    vasSettingsStore.setXRayModeEnabled(true);
+    await wrapper.vm.$nextTick();
+
+    expect(vm(wrapper).visible).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(vm(wrapper).visible).toBe(false);
+  });
+
+  test('restarts the hide timer on a rapid re-toggle instead of hiding early', async () => {
+    const wrapper = mountComponent();
+
+    vasSettingsStore.setXRayModeEnabled(true);
+    await wrapper.vm.$nextTick();
+
+    await vi.advanceTimersByTimeAsync(2000);
+    vasSettingsStore.setXRayModeEnabled(false);
+    await wrapper.vm.$nextTick();
+
+    await vi.advanceTimersByTimeAsync(2000);
+
+    // Still visible: the second toggle reset the ~2.5s timer, so only 2s have passed since then.
+    expect(vm(wrapper).visible).toBe(true);
+    expect(vm(wrapper).message).toBe('X-ray mode disabled');
+  });
+});

--- a/tests/unit/specs/plugins/x-ray-inspector.test.ts
+++ b/tests/unit/specs/plugins/x-ray-inspector.test.ts
@@ -1,0 +1,31 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, test } from 'vitest';
+import vasXRayInspector from '../../../../src/plugins/x-ray-inspector';
+import { hasComponentMarker } from '../../../../src/utils/vue-component-inspector';
+
+describe('vasXRayInspector', () => {
+  test('marks a mounted component root element with its name', () => {
+    const comp = { name: 'hello', template: '<div>Hello</div>' };
+
+    const wrapper = mount(comp, { global: { plugins: [vasXRayInspector] } });
+
+    expect(hasComponentMarker(wrapper.element)).toBe(true);
+  });
+
+  test('does not mark anything when the plugin is not installed', () => {
+    const comp = { name: 'hello', template: '<div>Hello</div>' };
+
+    const wrapper = mount(comp);
+
+    expect(hasComponentMarker(wrapper.element)).toBe(false);
+  });
+
+  test('marks every component sharing the same root element, not just the outermost one', () => {
+    const child = { name: 'child', template: '<button>Click</button>' };
+    const parent = { name: 'parent', components: { child }, template: '<child />' };
+
+    const wrapper = mount(parent, { global: { plugins: [vasXRayInspector] } });
+
+    expect(hasComponentMarker(wrapper.element)).toBe(true);
+  });
+});

--- a/tests/unit/specs/utils/vue-component-inspector.test.ts
+++ b/tests/unit/specs/utils/vue-component-inspector.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import {
+  collectStackedInstances,
   findComponentInstance,
   formatCopyText,
   getComponentDisplayName,
@@ -7,7 +8,11 @@ import {
   resolveComponentAtElement,
 } from '../../../../src/utils/vue-component-inspector';
 
-type FakeInstance = { type: { name?: string; __name?: string; __file?: string } };
+type FakeInstance = {
+  type: { name?: string; __name?: string; __file?: string };
+  parent?: FakeInstance | null;
+  vnode?: { el: unknown };
+};
 
 const withVueInstance = (el: Element, instance: FakeInstance): Element => {
   Object.assign(el, { __vueParentComponent: instance });
@@ -48,33 +53,61 @@ describe('findComponentInstance', () => {
   });
 });
 
+describe('collectStackedInstances', () => {
+  test('returns a single-entry stack when no parent shares the same root element', () => {
+    const el = document.createElement('div');
+    const instance: FakeInstance = { type: { name: 'c-vas-demo-card' }, parent: null, vnode: { el } };
+
+    expect(collectStackedInstances(instance as never, el)).toEqual([instance]);
+  });
+
+  test('collects every layer collapsed onto the same DOM node (e.g. a wrapper around a library component)', () => {
+    const el = document.createElement('button');
+    const outer: FakeInstance = { type: { name: 'e-button', __file: '/repo/src/elements/e-button.vue' }, parent: null, vnode: { el } };
+    const inner: FakeInstance = { type: { name: 'VBtn' }, parent: outer, vnode: { el } };
+
+    expect(collectStackedInstances(inner as never, el)).toEqual([inner, outer]);
+  });
+
+  test('stops once a parent renders a different root element', () => {
+    const el = document.createElement('button');
+    const otherElement = document.createElement('div');
+    const outer: FakeInstance = { type: { name: 'r-demo-page' }, parent: null, vnode: { el: otherElement } };
+    const inner: FakeInstance = { type: { name: 'VBtn' }, parent: outer, vnode: { el } };
+
+    expect(collectStackedInstances(inner as never, el)).toEqual([inner]);
+  });
+});
+
 describe('getComponentDisplayName', () => {
   test('prefers the explicit Options API name', () => {
-    expect(getComponentDisplayName({ type: { name: 'c-vas-demo-card', __name: 'anon' } })).toBe('c-vas-demo-card');
+    expect(getComponentDisplayName({ type: { name: 'c-vas-demo-card', __name: 'anon' } } as never)).toBe(
+      'c-vas-demo-card',
+    );
   });
 
   test('falls back to the compiler-injected __name', () => {
-    expect(getComponentDisplayName({ type: { __name: 'r-demo-page' } })).toBe('r-demo-page');
+    expect(getComponentDisplayName({ type: { __name: 'r-demo-page' } } as never)).toBe('r-demo-page');
   });
 
   test('returns null when neither is present', () => {
-    expect(getComponentDisplayName({ type: {} })).toBeNull();
+    expect(getComponentDisplayName({ type: {} } as never)).toBeNull();
   });
 });
 
 describe('getComponentFilePath', () => {
   test('returns null when no __file is present', () => {
-    expect(getComponentFilePath({ type: {} })).toBeNull();
+    expect(getComponentFilePath({ type: {} } as never)).toBeNull();
   });
 
   test('trims the absolute path down to the last /src/ segment', () => {
-    const file = getComponentFilePath({ type: { __file: '/Users/dev/project/src/components/UserCard.vue' } });
+    const file = getComponentFilePath({ type: { __file: '/Users/dev/project/src/components/UserCard.vue' } } as never);
 
     expect(file).toBe('src/components/UserCard.vue');
   });
 
   test('returns the raw path when no /src/ marker is found', () => {
-    const file = getComponentFilePath({ type: { __file: '/Users/dev/project/UserCard.vue' } });
+    const file = getComponentFilePath({ type: { __file: '/Users/dev/project/UserCard.vue' } } as never);
 
     expect(file).toBe('/Users/dev/project/UserCard.vue');
   });
@@ -91,7 +124,7 @@ describe('resolveComponentAtElement', () => {
     expect(resolveComponentAtElement(el)).toBeNull();
   });
 
-  test('returns name, file, and the matched element', () => {
+  test('returns name, file, and the matched element for a plain (non-stacked) component', () => {
     const el = withVueInstance(document.createElement('div'), {
       type: { name: 'c-vas-demo-card', __file: '/repo/src/components/c-vas-demo-card.vue' },
     });
@@ -99,6 +132,35 @@ describe('resolveComponentAtElement', () => {
     expect(resolveComponentAtElement(el)).toEqual({
       name: 'c-vas-demo-card',
       file: 'src/components/c-vas-demo-card.vue',
+      wraps: null,
+      el,
+    });
+  });
+
+  test('prefers a same-root wrapper with a source file over an inner library component without one', () => {
+    const el = document.createElement('button');
+    const outer: FakeInstance = { type: { name: 'e-button', __file: '/repo/src/elements/e-button.vue' }, parent: null, vnode: { el } };
+
+    withVueInstance(el, { type: { name: 'VBtn' }, parent: outer, vnode: { el } });
+
+    expect(resolveComponentAtElement(el)).toEqual({
+      name: 'e-button',
+      file: 'src/elements/e-button.vue',
+      wraps: 'VBtn',
+      el,
+    });
+  });
+
+  test('falls back to the outermost layer when nothing in the stack has a source file', () => {
+    const el = document.createElement('button');
+    const outer: FakeInstance = { type: { name: 'SomeUiKitButton' }, parent: null, vnode: { el } };
+
+    withVueInstance(el, { type: { name: 'VBtn' }, parent: outer, vnode: { el } });
+
+    expect(resolveComponentAtElement(el)).toEqual({
+      name: 'SomeUiKitButton',
+      file: null,
+      wraps: 'VBtn',
       el,
     });
   });
@@ -106,12 +168,18 @@ describe('resolveComponentAtElement', () => {
 
 describe('formatCopyText', () => {
   test('combines name and file when a file path exists', () => {
-    expect(formatCopyText({ name: 'UserCard', file: 'src/components/UserCard.vue', el: document.body })).toBe(
-      'UserCard (src/components/UserCard.vue)',
-    );
+    expect(
+      formatCopyText({ name: 'UserCard', file: 'src/components/UserCard.vue', wraps: null, el: document.body }),
+    ).toBe('UserCard (src/components/UserCard.vue)');
   });
 
   test('falls back to just the name when no file path exists', () => {
-    expect(formatCopyText({ name: 'UserCard', file: null, el: document.body })).toBe('UserCard');
+    expect(formatCopyText({ name: 'UserCard', file: null, wraps: null, el: document.body })).toBe('UserCard');
+  });
+
+  test('appends the wrapped component when one was substituted in', () => {
+    expect(
+      formatCopyText({ name: 'e-button', file: 'src/elements/e-button.vue', wraps: 'VBtn', el: document.body }),
+    ).toBe('e-button (src/elements/e-button.vue) — wraps VBtn');
   });
 });

--- a/tests/unit/specs/utils/vue-component-inspector.test.ts
+++ b/tests/unit/specs/utils/vue-component-inspector.test.ts
@@ -9,6 +9,7 @@ import {
   hasComponentMarker,
   markComponentInstance,
   resolveComponentAtElement,
+  toProjectRelativePath,
 } from '../../../../src/utils/vue-component-inspector';
 
 type FakeInstance = {
@@ -109,10 +110,28 @@ describe('getComponentFilePath', () => {
     expect(file).toBe('src/components/UserCard.vue');
   });
 
-  test('returns the raw path when no /src/ marker is found', () => {
+  test('returns null when no /src/ marker is found, rather than leaking the absolute path', () => {
     const file = getComponentFilePath({ type: { __file: '/Users/dev/project/UserCard.vue' } } as never);
 
-    expect(file).toBe('/Users/dev/project/UserCard.vue');
+    expect(file).toBeNull();
+  });
+});
+
+describe('toProjectRelativePath', () => {
+  test('returns null for a nullish input', () => {
+    expect(toProjectRelativePath(null)).toBeNull();
+    // eslint-disable-next-line unicorn/no-useless-undefined -- exercising the undefined branch of the union type
+    expect(toProjectRelativePath(undefined)).toBeNull();
+  });
+
+  test('trims an absolute path down to the last /src/ segment', () => {
+    expect(toProjectRelativePath('/Users/dev/project/src/components/UserCard.vue')).toBe(
+      'src/components/UserCard.vue',
+    );
+  });
+
+  test('returns null (never the raw absolute path) when no /src/ marker is found', () => {
+    expect(toProjectRelativePath('/Users/dev/project/UserCard.vue')).toBeNull();
   });
 });
 
@@ -195,7 +214,7 @@ describe('markComponentInstance', () => {
   test('does nothing for a non-Element target', () => {
     const fakeElement = {};
 
-    markComponentInstance(fakeElement, 'e-button', 'src/elements/e-button.vue');
+    markComponentInstance(fakeElement, 'e-button', '/repo/src/elements/e-button.vue');
 
     expect(hasComponentMarker(fakeElement)).toBe(false);
   });
@@ -203,7 +222,7 @@ describe('markComponentInstance', () => {
   test('does nothing when name is null', () => {
     const el = document.createElement('div');
 
-    markComponentInstance(el, null, 'src/elements/e-button.vue');
+    markComponentInstance(el, null, '/repo/src/elements/e-button.vue');
 
     expect(hasComponentMarker(el)).toBe(false);
   });
@@ -212,9 +231,27 @@ describe('markComponentInstance', () => {
     const el = document.createElement('button');
 
     markComponentInstance(el, 'VBtn', null);
-    markComponentInstance(el, 'e-button', 'src/elements/e-button.vue');
+    markComponentInstance(el, 'e-button', '/repo/src/elements/e-button.vue');
 
     expect(hasComponentMarker(el)).toBe(true);
+  });
+
+  test('trims the raw absolute __file path to a project-relative one, never storing it as-is', () => {
+    const el = document.createElement('div');
+
+    markComponentInstance(el, 'c-vas-demo-card', '/Users/dev/project/src/components/c-vas-demo-card.vue');
+
+    expect(getComponentBreadcrumb(el)).toEqual([
+      { name: 'c-vas-demo-card', file: 'src/components/c-vas-demo-card.vue', wraps: null, el },
+    ]);
+  });
+
+  test('drops the file entirely (falls back to name-only) when no /src/ marker is found', () => {
+    const el = document.createElement('div');
+
+    markComponentInstance(el, 'c-vas-demo-card', '/Users/dev/project/c-vas-demo-card.vue');
+
+    expect(getComponentBreadcrumb(el)).toEqual([{ name: 'c-vas-demo-card', file: null, wraps: null, el }]);
   });
 });
 
@@ -230,7 +267,7 @@ describe('hasComponentMarker', () => {
   test('returns true once the element has been marked', () => {
     const el = document.createElement('div');
 
-    markComponentInstance(el, 'c-vas-demo-card', 'src/components/c-vas-demo-card.vue');
+    markComponentInstance(el, 'c-vas-demo-card', '/repo/src/components/c-vas-demo-card.vue');
 
     expect(hasComponentMarker(el)).toBe(true);
   });
@@ -246,8 +283,8 @@ describe('getComponentBreadcrumb', () => {
     const wrapper = document.createElement('div'); // plain DOM node, e.g. a layout <div> — no marker
     const button = document.createElement('button');
 
-    markComponentInstance(card, 'ProductCard', 'src/components/ProductCard.vue');
-    markComponentInstance(button, 'e-button', 'src/elements/e-button.vue');
+    markComponentInstance(card, 'ProductCard', '/repo/src/components/ProductCard.vue');
+    markComponentInstance(button, 'e-button', '/repo/src/elements/e-button.vue');
 
     card.append(wrapper);
     wrapper.append(button);
@@ -264,7 +301,7 @@ describe('getComponentBreadcrumb', () => {
     const el = document.createElement('button');
 
     markComponentInstance(el, 'VBtn', null);
-    markComponentInstance(el, 'e-button', 'src/elements/e-button.vue');
+    markComponentInstance(el, 'e-button', '/repo/src/elements/e-button.vue');
 
     expect(getComponentBreadcrumb(el)).toEqual([
       { name: 'e-button', file: 'src/elements/e-button.vue', wraps: 'VBtn', el },
@@ -283,19 +320,19 @@ describe('getComponentBreadcrumb', () => {
 });
 
 describe('formatCopyText', () => {
-  test('combines name and file when a file path exists', () => {
+  test('prefers the file path over the name when a file is resolvable', () => {
     expect(
       formatCopyText({ name: 'UserCard', file: 'src/components/UserCard.vue', wraps: null, el: document.body }),
-    ).toBe('UserCard (src/components/UserCard.vue)');
+    ).toBe('src/components/UserCard.vue');
   });
 
-  test('falls back to just the name when no file path exists', () => {
+  test('falls back to the bare name when no file path exists', () => {
     expect(formatCopyText({ name: 'UserCard', file: null, wraps: null, el: document.body })).toBe('UserCard');
   });
 
-  test('appends the wrapped component when one was substituted in', () => {
+  test('ignores wraps entirely — the copy payload is always exactly one of file or name', () => {
     expect(
       formatCopyText({ name: 'e-button', file: 'src/elements/e-button.vue', wraps: 'VBtn', el: document.body }),
-    ).toBe('e-button (src/elements/e-button.vue) — wraps VBtn');
+    ).toBe('src/elements/e-button.vue');
   });
 });

--- a/tests/unit/specs/utils/vue-component-inspector.test.ts
+++ b/tests/unit/specs/utils/vue-component-inspector.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'vitest';
+import {
+  findComponentInstance,
+  formatCopyText,
+  getComponentDisplayName,
+  getComponentFilePath,
+  resolveComponentAtElement,
+} from '../../../../src/utils/vue-component-inspector';
+
+type FakeInstance = { type: { name?: string; __name?: string; __file?: string } };
+
+const withVueInstance = (el: Element, instance: FakeInstance): Element => {
+  Object.assign(el, { __vueParentComponent: instance });
+
+  return el;
+};
+
+describe('findComponentInstance', () => {
+  test('returns null for null input', () => {
+    expect(findComponentInstance(null)).toBeNull();
+  });
+
+  test('returns null when no ancestor has a Vue instance attached', () => {
+    const parent = document.createElement('div');
+    const child = document.createElement('span');
+
+    parent.append(child);
+
+    expect(findComponentInstance(child)).toBeNull();
+  });
+
+  test('finds the instance on the element itself', () => {
+    const el = withVueInstance(document.createElement('div'), { type: { name: 'c-vas-demo-card' } });
+
+    expect(findComponentInstance(el)?.el).toBe(el);
+  });
+
+  test('walks up to the nearest ancestor carrying a Vue instance', () => {
+    const root = withVueInstance(document.createElement('div'), { type: { name: 'r-demo-page' } });
+    const leaf = document.createElement('span');
+
+    root.append(leaf);
+
+    const found = findComponentInstance(leaf);
+
+    expect(found?.el).toBe(root);
+    expect(found?.instance.type.name).toBe('r-demo-page');
+  });
+});
+
+describe('getComponentDisplayName', () => {
+  test('prefers the explicit Options API name', () => {
+    expect(getComponentDisplayName({ type: { name: 'c-vas-demo-card', __name: 'anon' } })).toBe('c-vas-demo-card');
+  });
+
+  test('falls back to the compiler-injected __name', () => {
+    expect(getComponentDisplayName({ type: { __name: 'r-demo-page' } })).toBe('r-demo-page');
+  });
+
+  test('returns null when neither is present', () => {
+    expect(getComponentDisplayName({ type: {} })).toBeNull();
+  });
+});
+
+describe('getComponentFilePath', () => {
+  test('returns null when no __file is present', () => {
+    expect(getComponentFilePath({ type: {} })).toBeNull();
+  });
+
+  test('trims the absolute path down to the last /src/ segment', () => {
+    const file = getComponentFilePath({ type: { __file: '/Users/dev/project/src/components/UserCard.vue' } });
+
+    expect(file).toBe('src/components/UserCard.vue');
+  });
+
+  test('returns the raw path when no /src/ marker is found', () => {
+    const file = getComponentFilePath({ type: { __file: '/Users/dev/project/UserCard.vue' } });
+
+    expect(file).toBe('/Users/dev/project/UserCard.vue');
+  });
+});
+
+describe('resolveComponentAtElement', () => {
+  test('returns null when nothing resolves', () => {
+    expect(resolveComponentAtElement(document.createElement('div'))).toBeNull();
+  });
+
+  test('returns null when the matched instance has no resolvable name', () => {
+    const el = withVueInstance(document.createElement('div'), { type: {} });
+
+    expect(resolveComponentAtElement(el)).toBeNull();
+  });
+
+  test('returns name, file, and the matched element', () => {
+    const el = withVueInstance(document.createElement('div'), {
+      type: { name: 'c-vas-demo-card', __file: '/repo/src/components/c-vas-demo-card.vue' },
+    });
+
+    expect(resolveComponentAtElement(el)).toEqual({
+      name: 'c-vas-demo-card',
+      file: 'src/components/c-vas-demo-card.vue',
+      el,
+    });
+  });
+});
+
+describe('formatCopyText', () => {
+  test('combines name and file when a file path exists', () => {
+    expect(formatCopyText({ name: 'UserCard', file: 'src/components/UserCard.vue', el: document.body })).toBe(
+      'UserCard (src/components/UserCard.vue)',
+    );
+  });
+
+  test('falls back to just the name when no file path exists', () => {
+    expect(formatCopyText({ name: 'UserCard', file: null, el: document.body })).toBe('UserCard');
+  });
+});

--- a/tests/unit/specs/utils/vue-component-inspector.test.ts
+++ b/tests/unit/specs/utils/vue-component-inspector.test.ts
@@ -3,8 +3,11 @@ import {
   collectStackedInstances,
   findComponentInstance,
   formatCopyText,
+  getComponentBreadcrumb,
   getComponentDisplayName,
   getComponentFilePath,
+  hasComponentMarker,
+  markComponentInstance,
   resolveComponentAtElement,
 } from '../../../../src/utils/vue-component-inspector';
 
@@ -151,18 +154,131 @@ describe('resolveComponentAtElement', () => {
     });
   });
 
-  test('falls back to the outermost layer when nothing in the stack has a source file', () => {
+  test('falls back to the innermost layer when nothing in the stack has a source file', () => {
     const el = document.createElement('button');
     const outer: FakeInstance = { type: { name: 'SomeUiKitButton' }, parent: null, vnode: { el } };
 
     withVueInstance(el, { type: { name: 'VBtn' }, parent: outer, vnode: { el } });
 
     expect(resolveComponentAtElement(el)).toEqual({
-      name: 'SomeUiKitButton',
+      name: 'VBtn',
       file: null,
+      wraps: null,
+      el,
+    });
+  });
+
+  test('stops at the first same-root layer with a source file, not the outermost one', () => {
+    // Regression test: a deep stack of consumer-owned wrappers (e.g. AppShell > Section > e-button)
+    // all collapsed onto the same DOM node used to resolve to the outermost one (AppShell) instead
+    // of the most specific, actually-relevant one (e-button).
+    const el = document.createElement('button');
+    const appShell: FakeInstance = { type: { name: 'AppShell', __file: '/repo/src/layouts/AppShell.vue' }, parent: null, vnode: { el } };
+    const eButton: FakeInstance = {
+      type: { name: 'e-button', __file: '/repo/src/elements/e-button.vue' },
+      parent: appShell,
+      vnode: { el },
+    };
+
+    withVueInstance(el, { type: { name: 'VBtn' }, parent: eButton, vnode: { el } });
+
+    expect(resolveComponentAtElement(el)).toEqual({
+      name: 'e-button',
+      file: 'src/elements/e-button.vue',
       wraps: 'VBtn',
       el,
     });
+  });
+});
+
+describe('markComponentInstance', () => {
+  test('does nothing for a non-Element target', () => {
+    const fakeElement = {};
+
+    markComponentInstance(fakeElement, 'e-button', 'src/elements/e-button.vue');
+
+    expect(hasComponentMarker(fakeElement)).toBe(false);
+  });
+
+  test('does nothing when name is null', () => {
+    const el = document.createElement('div');
+
+    markComponentInstance(el, null, 'src/elements/e-button.vue');
+
+    expect(hasComponentMarker(el)).toBe(false);
+  });
+
+  test('accumulates multiple marks on the same element instead of overwriting', () => {
+    const el = document.createElement('button');
+
+    markComponentInstance(el, 'VBtn', null);
+    markComponentInstance(el, 'e-button', 'src/elements/e-button.vue');
+
+    expect(hasComponentMarker(el)).toBe(true);
+  });
+});
+
+describe('hasComponentMarker', () => {
+  test('returns false for a plain element with no marks', () => {
+    expect(hasComponentMarker(document.createElement('div'))).toBe(false);
+  });
+
+  test('returns false for a non-Element value', () => {
+    expect(hasComponentMarker(null)).toBe(false);
+  });
+
+  test('returns true once the element has been marked', () => {
+    const el = document.createElement('div');
+
+    markComponentInstance(el, 'c-vas-demo-card', 'src/components/c-vas-demo-card.vue');
+
+    expect(hasComponentMarker(el)).toBe(true);
+  });
+});
+
+describe('getComponentBreadcrumb', () => {
+  test('returns an empty array when nothing resolves at all', () => {
+    expect(getComponentBreadcrumb(document.createElement('div'))).toEqual([]);
+  });
+
+  test('builds a component-only chain, nearest first, skipping unmarked DOM nodes in between', () => {
+    const card = document.createElement('div');
+    const wrapper = document.createElement('div'); // plain DOM node, e.g. a layout <div> — no marker
+    const button = document.createElement('button');
+
+    markComponentInstance(card, 'ProductCard', 'src/components/ProductCard.vue');
+    markComponentInstance(button, 'e-button', 'src/elements/e-button.vue');
+
+    card.append(wrapper);
+    wrapper.append(button);
+
+    const breadcrumb = getComponentBreadcrumb(button);
+
+    expect(breadcrumb).toEqual([
+      { name: 'e-button', file: 'src/elements/e-button.vue', wraps: null, el: button },
+      { name: 'ProductCard', file: 'src/components/ProductCard.vue', wraps: null, el: card },
+    ]);
+  });
+
+  test('prefers the innermost marked layer with a file when several stack on the same node', () => {
+    const el = document.createElement('button');
+
+    markComponentInstance(el, 'VBtn', null);
+    markComponentInstance(el, 'e-button', 'src/elements/e-button.vue');
+
+    expect(getComponentBreadcrumb(el)).toEqual([
+      { name: 'e-button', file: 'src/elements/e-button.vue', wraps: 'VBtn', el },
+    ]);
+  });
+
+  test('falls back to the __vueParentComponent-based resolution when no marker exists anywhere', () => {
+    const el = withVueInstance(document.createElement('div'), {
+      type: { name: 'c-vas-demo-card', __file: '/repo/src/components/c-vas-demo-card.vue' },
+    });
+
+    expect(getComponentBreadcrumb(el)).toEqual([
+      { name: 'c-vas-demo-card', file: 'src/components/c-vas-demo-card.vue', wraps: null, el },
+    ]);
   });
 });
 


### PR DESCRIPTION
  Adds **X-ray mode**: a hover inspector in the styleguide sidebar for quickly identifying
  the Vue component behind any element on the page (name + source file), primarily to speed
  up writing AI coding prompts.

  - Hover any element to highlight the Vue component it belongs to; click (or press
  **Enter**) to copy its project-relative file path — or bare component/tag name if no file
  can be resolved — to the clipboard.
  - **Alt+↑ / Alt+↓** (`⌥` on Mac) steps through the component-only ancestor chain at the
  hovered point, skipping plain DOM nodes.
  - Toggle via the Features panel or **Ctrl+Alt+X** / **⌘+⌥+X**; **Esc** also turns it off.
  A brief top-right toast confirms on/off either way.
  - New optional `vasXRayInspector` plugin (`app.use(vasXRayInspector)`, dev-only) registers
  a global mixin that marks every component's root element — including third-party ones
  (e.g. Vuetify) — for accurate detection. Without it, detection falls back to a best-effort
  heuristic and a warning appears under the toggle with a link to the setup guide
  (`docs/x-ray-mode.md`).
  - File paths are always trimmed to be project-relative (starting at `src/`); the raw
  absolute filesystem path is never copied — falls back to the name instead if it can't be
  resolved.

  ## Test plan

  - [ ] `npm run test` passes (lint, type-check, unit tests)
  - [ ] `npm run dev`, enable **X-ray mode** in the Features panel → toast appears top-right
  ("X-ray mode enabled")
  - [ ] Hover various elements (native HTML, your own components, third-party library
  components if available) → highlight box + label with name/file appear
  - [ ] Click a highlighted element → path or name copied to clipboard, and the underlying
  click is suppressed (no navigation/submit)
  - [ ] Press **Enter** while hovering → same copy behavior without using the mouse
  - [ ] Hover a nested component and press **Alt+↑ / Alt+↓** → selection steps through
  ancestor components; counter (`2/5`) shows when applicable
  - [ ] Press **Ctrl+Alt+X** (`⌘+⌥+X` on Mac) → toggles x-ray mode on/off, toast confirms
  - [ ] Press **Esc** while x-ray mode is on → it turns off, toast confirms "disabled"
  - [ ] (Optional, for full coverage) Register `vasXRayInspector` in a consumer project per
  `docs/x-ray-mode.md` and confirm the setup warning disappears and detection through a
  wrapped third-party component (e.g. a component rendering `<v-btn>`) shows your component,
  not the library one